### PR TITLE
Add more content view in CardDetails screen

### DIFF
--- a/app/src/main/kotlin/com/donghanx/nowinmtg/navigation/NimNavHost.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/navigation/NimNavHost.kt
@@ -28,7 +28,10 @@ fun NimNavHost(
             onShowSnackbar = onShowSnackbar
         )
         setsScreen(onShowSnackbar = onShowSnackbar)
-        cardDetailsScreen(onShowSnackbar = onShowSnackbar)
+        cardDetailsScreen(
+            onBackClick = navController::popBackStack,
+            onShowSnackbar = onShowSnackbar
+        )
         searchScreen(onCloseClick = navController::popBackStack)
     }
 }

--- a/core/database/src/main/kotlin/com/donghanx/database/NimDatabase.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/NimDatabase.kt
@@ -3,6 +3,7 @@ package com.donghanx.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import com.donghanx.database.converter.RulingsConverter
 import com.donghanx.database.converter.StringListTypeConverters
 import com.donghanx.database.model.CardDetailsEntity
 import com.donghanx.database.model.RandomCardEntity
@@ -12,7 +13,7 @@ import com.donghanx.database.model.SetEntity
     entities = [RandomCardEntity::class, CardDetailsEntity::class, SetEntity::class],
     version = 1
 )
-@TypeConverters(StringListTypeConverters::class)
+@TypeConverters(StringListTypeConverters::class, RulingsConverter::class)
 abstract class NimDatabase : RoomDatabase() {
 
     abstract fun randomCardsDao(): RandomCardsDao

--- a/core/database/src/main/kotlin/com/donghanx/database/converter/RulingsConverter.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/converter/RulingsConverter.kt
@@ -1,0 +1,18 @@
+package com.donghanx.database.converter
+
+import androidx.room.TypeConverter
+import com.donghanx.model.network.Ruling
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class RulingsConverter {
+    @TypeConverter
+    fun fromRulings(rulings: List<Ruling>): String {
+        return Json.encodeToString(rulings)
+    }
+
+    @TypeConverter
+    fun toRulings(string: String?): List<Ruling>? {
+        return string?.let { Json.decodeFromString<List<Ruling>>(it) }
+    }
+}

--- a/core/database/src/main/kotlin/com/donghanx/database/converter/StringListTypeConverters.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/converter/StringListTypeConverters.kt
@@ -13,7 +13,7 @@ object StringListTypeConverters {
 
     @TypeConverter
     @JvmStatic
-    fun fromStringList(strings: List<String>): String? {
+    fun fromStringList(strings: List<String>): String {
         return Json.encodeToString(strings)
     }
 }

--- a/core/database/src/main/kotlin/com/donghanx/database/model/CardDetailsEntity.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/model/CardDetailsEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.donghanx.model.CardDetails
 import com.donghanx.model.network.NetworkCardDetails
+import com.donghanx.model.network.Ruling
 
 @Entity(tableName = "card_details")
 data class CardDetailsEntity(
@@ -32,7 +33,8 @@ data class CardDetailsEntity(
     val toughness: String?,
     val type: String,
     val types: List<String>?,
-    val variations: List<String>?
+    val variations: List<String>?,
+    val rulings: List<Ruling>?
 )
 
 fun NetworkCardDetails.asCardDetailsEntity(): CardDetailsEntity =
@@ -62,7 +64,8 @@ fun NetworkCardDetails.asCardDetailsEntity(): CardDetailsEntity =
         toughness = toughness,
         type = type,
         types = types,
-        variations = variations
+        variations = variations,
+        rulings = rulings
     )
 
 fun CardDetailsEntity.asExternalModel(): CardDetails =
@@ -92,5 +95,6 @@ fun CardDetailsEntity.asExternalModel(): CardDetails =
         toughness = toughness,
         type = type,
         types = types,
-        variations = variations
+        variations = variations,
+        rulings = rulings
     )

--- a/core/design/src/main/kotlin/com/donghanx/design/ui/card/ExpandableCard.kt
+++ b/core/design/src/main/kotlin/com/donghanx/design/ui/card/ExpandableCard.kt
@@ -1,0 +1,55 @@
+package com.donghanx.design.ui.card
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ExpandableCard(
+    headerTitle: String,
+    modifier: Modifier = Modifier,
+    expandedContent: @Composable () -> Unit
+) {
+    val (expanded, setExpanded) = remember { mutableStateOf(true) }
+
+    Card(
+        modifier =
+            modifier.fillMaxWidth().wrapContentHeight().padding(horizontal = 8.dp).clickable(
+                interactionSource = MutableInteractionSource(),
+                indication = null
+            ) {
+                setExpanded(!expanded)
+            }
+    ) {
+        AnimatedContent(
+            targetState = expanded,
+            modifier = Modifier.padding(all = 8.dp),
+            label = "Expandable Card"
+        ) { expanded ->
+            if (!expanded)
+                Row {
+                    Text(text = headerTitle, fontWeight = FontWeight.Medium)
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Icon(imageVector = Icons.Filled.ArrowDropDown, contentDescription = null)
+                }
+            else expandedContent()
+        }
+    }
+}

--- a/core/design/src/main/res/values/string.xml
+++ b/core/design/src/main/res/values/string.xml
@@ -3,4 +3,5 @@
     <string name="scroll_to_top">Scroll To Top</string>
     <string name="search">Search</string>
     <string name="back">Back</string>
+    <string name="favorite">Favorite</string>
 </resources>

--- a/core/model/src/main/kotlin/com/donghanx/mock/MockUtils.kt
+++ b/core/model/src/main/kotlin/com/donghanx/mock/MockUtils.kt
@@ -3,6 +3,7 @@ package com.donghanx.mock
 import com.donghanx.model.CardDetails
 import com.donghanx.model.CardPreview
 import com.donghanx.model.SetInfo
+import com.donghanx.model.network.Ruling
 
 object MockUtils {
     val emptyCards = List(5) { CardPreview(id = it.toString(), name = "", imageUrl = "") }
@@ -30,29 +31,24 @@ object MockUtils {
             multiverseId = "409741",
             imageUrl =
                 "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=409741&type=card",
-            //            rulings =
-            //                listOf(
-            //                    Ruling(
-            //                        date = "2016-04-08",
-            //                        text =
-            //                            "Archangel Avacyn’s delayed triggered ability triggers at
-            // the beginning of the next upkeep regardless of whose turn it is."
-            //                    ),
-            //                    Ruling(
-            //                        date = "2016-04-08",
-            //                        text =
-            //                            "Archangel Avacyn’s delayed triggered ability won’t cause
-            // it to transform back into Archangel Avacyn if it has already transformed into Avacyn,
-            // the Purifier, perhaps because several creatures died in one turn."
-            //                    ),
-            //                    Ruling(
-            //                        date = "2016-04-08",
-            //                        text =
-            //                            "For more information on double-faced cards, see the
-            // Shadows over Innistrad mechanics article
-            // (http://magic.wizards.com/en/articles/archive/feature/shadows-over-innistrad-mechanics)."
-            //                    )
-            //                ),
+            rulings =
+                listOf(
+                    Ruling(
+                        date = "2016-04-08",
+                        text =
+                            "Archangel Avacyn’s delayed triggered ability triggers at the beginning of the next upkeep regardless of whose turn it is."
+                    ),
+                    Ruling(
+                        date = "2016-04-08",
+                        text =
+                            "Archangel Avacyn’s delayed triggered ability won’t cause it to transform back into Archangel Avacyn if it has already transformed into Avacyn, the Purifier, perhaps because several creatures died in one turn."
+                    ),
+                    Ruling(
+                        date = "2016-04-08",
+                        text =
+                            "For more information on double-faced cards, see the Shadows over Innistrad mechanics article(http://magic.wizards.com/en/articles/archive/feature/shadows-over-innistrad-mechanics)."
+                    )
+                ),
             //            foreignNames =
             //                listOf(
             //                    ForeignName(
@@ -124,7 +120,8 @@ object MockUtils {
             id = "ad53597a-4448-5cbd-82bf-11d163b0c14f",
             flavor = null,
             setName = "Shadows over Innistrad",
-            variations = null
+            variations = null,
+            rulings = null
         )
 
     val soiExpansion =

--- a/core/model/src/main/kotlin/com/donghanx/model/CardDetails.kt
+++ b/core/model/src/main/kotlin/com/donghanx/model/CardDetails.kt
@@ -1,5 +1,7 @@
 package com.donghanx.model
 
+import com.donghanx.model.network.Ruling
+
 data class CardDetails(
     val id: String,
     val multiverseId: String?,
@@ -26,5 +28,6 @@ data class CardDetails(
     val toughness: String?,
     val type: String,
     val types: List<String>?,
-    val variations: List<String>?
+    val variations: List<String>?,
+    val rulings: List<Ruling>?
 )

--- a/core/model/src/main/kotlin/com/donghanx/model/network/NetworkCardDetails.kt
+++ b/core/model/src/main/kotlin/com/donghanx/model/network/NetworkCardDetails.kt
@@ -37,7 +37,7 @@ data class NetworkCardDetails(
     @SerialName("watermark") val watermark: String?,
     //    @SerialName("foreignNames") val foreignNames: List<ForeignName>?,
     //    @SerialName("legalities") val legalities: List<Legality>?,
-    //    @SerialName("rulings") val rulings: List<Ruling>?,
+    @SerialName("rulings") val rulings: List<Ruling>?,
 )
 
 @Serializable

--- a/core/ui/src/androidTest/kotlin/com/donghanx/ui/ExampleInstrumentedTest.kt
+++ b/core/ui/src/androidTest/kotlin/com/donghanx/ui/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package com.donghanx.ui
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/core/ui/src/test/kotlin/com/donghanx/ui/ExampleUnitTest.kt
+++ b/core/ui/src/test/kotlin/com/donghanx/ui/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package com.donghanx.ui
 
-import org.junit.Test
-
 import org.junit.Assert.*
+import org.junit.Test
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/CardDetailsScreen.kt
+++ b/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/CardDetailsScreen.kt
@@ -1,24 +1,37 @@
 package com.donghanx.carddetails
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.donghanx.design.R as DesignR
 import com.donghanx.design.ui.pullrefresh.PullRefreshIndicator
 import com.donghanx.design.ui.pullrefresh.pullRefresh
 import com.donghanx.design.ui.pullrefresh.rememberPullRefreshState
 
 @Composable
 fun CardDetailsScreen(
+    onBackClick: () -> Unit,
     onShowSnackbar: suspend (message: String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: CardDetailsViewModel = hiltViewModel()
@@ -35,17 +48,21 @@ fun CardDetailsScreen(
         modifier = modifier.fillMaxSize().pullRefresh(state = pullRefreshState),
         contentAlignment = Alignment.Center
     ) {
-        Column(
-            modifier = Modifier.fillMaxSize().verticalScroll(state = rememberScrollState()),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            when (val uiState = cardDetailsUiState) {
-                is CardDetailsUiState.Success -> {
-                    CardDetailsView(cardDetails = uiState.cardDetails)
-                }
-                is CardDetailsUiState.NoCardDetails -> {
-                    // TODO: use a more intuitive placeholder view instead
-                    CircularProgressIndicator()
+        Column {
+            CardDetailsTopBar(onBackClick = onBackClick)
+
+            Box(
+                modifier = Modifier.fillMaxSize().verticalScroll(state = rememberScrollState()),
+                contentAlignment = Alignment.TopCenter
+            ) {
+                when (val uiState = cardDetailsUiState) {
+                    is CardDetailsUiState.Success -> {
+                        CardDetailsView(cardDetails = uiState.cardDetails)
+                    }
+                    is CardDetailsUiState.NoCardDetails -> {
+                        // TODO: use a more intuitive placeholder view instead
+                        CircularProgressIndicator()
+                    }
                 }
             }
         }
@@ -60,6 +77,30 @@ fun CardDetailsScreen(
             if (cardDetailsUiState.hasError()) {
                 onShowSnackbar(cardDetailsUiState.errorMessage())
             }
+        }
+    }
+}
+
+@Composable
+private fun CardDetailsTopBar(onBackClick: () -> Unit, modifier: Modifier = Modifier) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.fillMaxWidth().padding(bottom = 12.dp),
+    ) {
+        IconButton(onClick = onBackClick) {
+            Icon(
+                imageVector = Icons.Filled.ArrowBack,
+                contentDescription = stringResource(id = DesignR.string.back)
+            )
+        }
+
+        // TODO: add functionality to mark a card as "favorite"
+        IconButton(onClick = {}) {
+            Icon(
+                imageVector = Icons.Filled.FavoriteBorder,
+                contentDescription = stringResource(id = DesignR.string.favorite)
+            )
         }
     }
 }

--- a/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/CardDetailsView.kt
+++ b/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/CardDetailsView.kt
@@ -3,10 +3,16 @@ package com.donghanx.carddetails
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -14,16 +20,25 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.donghanx.design.R
+import com.donghanx.design.R as DesignR
+import com.donghanx.design.ui.card.ExpandableCard
 import com.donghanx.mock.MockUtils
 import com.donghanx.model.CardDetails
+import com.donghanx.model.network.Ruling
 
 @Composable
 fun CardDetailsView(cardDetails: CardDetails, modifier: Modifier = Modifier) {
@@ -34,18 +49,138 @@ fun CardDetailsView(cardDetails: CardDetails, modifier: Modifier = Modifier) {
                     ImageRequest.Builder(LocalContext.current).data(cardDetails.imageUrl).build(),
                 contentDescription = cardDetails.name,
                 modifier = Modifier.weight(0.5F).aspectRatio(ratio = 5F / 7F),
-                placeholder = painterResource(id = R.drawable.blank_card_placeholder),
+                placeholder = painterResource(id = DesignR.drawable.blank_card_placeholder),
                 contentScale = ContentScale.Crop
             )
 
-            Column(
-                modifier = Modifier.weight(0.5F),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text(text = cardDetails.name, textAlign = TextAlign.Center)
-                Text(text = cardDetails.set)
+            CardBasicInfo(cardDetails, modifier.weight(weight = 0.5F))
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        CardDescription(cardDetails)
+    }
+}
+
+@Composable
+private fun CardBasicInfo(cardDetails: CardDetails, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(horizontal = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = cardDetails.name,
+            textAlign = TextAlign.Center,
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold
+        )
+
+        Text(
+            text = "${cardDetails.setName} (${cardDetails.set})",
+            textAlign = TextAlign.Center,
+            fontWeight = FontWeight.Medium
+        )
+        Divider()
+
+        Text(
+            text = cardDetails.type,
+            textAlign = TextAlign.Center,
+            fontSize = 16.sp,
+        )
+        Divider()
+
+        if (!cardDetails.power.isNullOrEmpty() && !cardDetails.toughness.isNullOrEmpty()) {
+            Text(
+                text = "${cardDetails.power}/${cardDetails.toughness}",
+                textAlign = TextAlign.Center,
+                fontSize = 16.sp,
+            )
+            Divider()
+        }
+
+        // TODO: parse manaCost string to a visualized form
+        cardDetails.manaCost?.let { manaCost ->
+            Text(
+                text = manaCost,
+                textAlign = TextAlign.Center,
+                fontSize = 16.sp,
+            )
+            Divider()
+        }
+
+        Text(
+            text = cardDetails.rarity,
+            textAlign = TextAlign.Center,
+            fontSize = 16.sp,
+        )
+        Divider()
+
+        cardDetails.artist?.let { artist ->
+            Column {
+                Text(
+                    text = stringResource(id = R.string.illustrated_by),
+                    textAlign = TextAlign.Center,
+                    fontSize = 16.sp
+                )
+                Text(
+                    text = artist,
+                    textAlign = TextAlign.Center,
+                    fontSize = 14.sp,
+                    fontStyle = FontStyle.Italic
+                )
             }
+        }
+    }
+}
+
+@Composable
+private fun CardDescription(cardDetails: CardDetails, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        cardDetails.text?.let { cardText ->
+            ExpandableCard(headerTitle = stringResource(id = R.string.card_text)) {
+                Text(text = cardText, textAlign = TextAlign.Start, fontWeight = FontWeight.Medium)
+            }
+        }
+
+        cardDetails.flavor?.let { cardFlavor ->
+            ExpandableCard(headerTitle = stringResource(id = R.string.flavor)) {
+                Text(
+                    text = cardFlavor,
+                    textAlign = TextAlign.Start,
+                    fontStyle = FontStyle.Italic,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+
+        cardDetails.rulings?.let { rulings ->
+            ExpandableCard(headerTitle = stringResource(id = R.string.rulings)) {
+                CardRulings(rulings = rulings)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CardRulings(rulings: List<Ruling>, modifier: Modifier = Modifier) {
+    LazyColumn(modifier = modifier.heightIn(max = 500.dp)) {
+        itemsIndexed(rulings) { index, currRuling ->
+            Text(
+                text =
+                    buildAnnotatedString {
+                        withStyle(style = SpanStyle(fontWeight = FontWeight.Medium)) {
+                            append(currRuling.date)
+                        }
+                        append(": ${currRuling.text}")
+                        if (index != rulings.lastIndex) append('\n')
+                    },
+                textAlign = TextAlign.Start,
+            )
         }
     }
 }

--- a/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/navigation/CardDetailsNavigation.kt
+++ b/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/navigation/CardDetailsNavigation.kt
@@ -12,8 +12,11 @@ fun NavController.navigateToCardDetails(cardId: String) {
     navigate(route = "$CARD_DETAILS_ROUTE/$cardId") { launchSingleTop = true }
 }
 
-fun NavGraphBuilder.cardDetailsScreen(onShowSnackbar: suspend (message: String) -> Unit) {
+fun NavGraphBuilder.cardDetailsScreen(
+    onBackClick: () -> Unit,
+    onShowSnackbar: suspend (message: String) -> Unit
+) {
     composable(route = "$CARD_DETAILS_ROUTE/{$CARD_ID_ARGS}") {
-        CardDetailsScreen(onShowSnackbar = onShowSnackbar)
+        CardDetailsScreen(onBackClick = onBackClick, onShowSnackbar = onShowSnackbar)
     }
 }

--- a/feature/carddetails/src/main/res/values/string.xml
+++ b/feature/carddetails/src/main/res/values/string.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="illustrated_by">Illustrated by</string>
+    <string name="card_details">Card Details</string>
+    <string name="card_text">Card Text</string>
+    <string name="flavor">Flavor</string>
+    <string name="rulings">Rulings</string>
+</resources>

--- a/feature/randomcards/src/main/kotlin/com/donghanx/randomcards/navigation/RandomCardsNavigation.kt
+++ b/feature/randomcards/src/main/kotlin/com/donghanx/randomcards/navigation/RandomCardsNavigation.kt
@@ -1,5 +1,10 @@
 package com.donghanx.randomcards.navigation
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.donghanx.randomcards.RandomCardsScreen
@@ -10,7 +15,17 @@ fun NavGraphBuilder.randomCardsScreen(
     onCardClick: (cardId: String) -> Unit,
     onShowSnackbar: suspend (message: String) -> Unit,
 ) {
-    composable(route = RANDOM_CARDS_ROUTE) {
+    composable(
+        route = RANDOM_CARDS_ROUTE,
+        enterTransition = {
+            fadeIn(animationSpec = tween(durationMillis = 300, easing = LinearEasing)) +
+                slideIntoContainer(towards = AnimatedContentTransitionScope.SlideDirection.Start)
+        },
+        exitTransition = {
+            fadeOut(animationSpec = tween(durationMillis = 300, easing = LinearEasing)) +
+                slideOutOfContainer(towards = AnimatedContentTransitionScope.SlideDirection.End)
+        }
+    ) {
         RandomCardsScreen(onCardClick = onCardClick, onShowSnackbar = onShowSnackbar)
     }
 }

--- a/feature/search/src/main/kotlin/com/donghanx/search/navigation/SearchNavigation.kt
+++ b/feature/search/src/main/kotlin/com/donghanx/search/navigation/SearchNavigation.kt
@@ -1,5 +1,6 @@
 package com.donghanx.search.navigation
 
+import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -14,5 +15,15 @@ fun NavController.navigateToSearch() {
 fun NavGraphBuilder.searchScreen(
     onCloseClick: () -> Unit,
 ) {
-    composable(route = SEARCH_ROUTE) { SearchScreen(onCloseClick = onCloseClick) }
+    composable(
+        route = SEARCH_ROUTE,
+        enterTransition = {
+            slideIntoContainer(towards = AnimatedContentTransitionScope.SlideDirection.Up)
+        },
+        exitTransition = {
+            slideOutOfContainer(towards = AnimatedContentTransitionScope.SlideDirection.Down)
+        }
+    ) {
+        SearchScreen(onCloseClick = onCloseClick)
+    }
 }


### PR DESCRIPTION
**Summary**
This PR adds two UI components in CardDetails screen:
- Basic Info: Card name, set, type, mana cost, power & toughness, rarity and the artist
- Description: Printed text, flavor and rulings