### PR TITLE
Adjust the CardsGallery and the primary navigation based on window size

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material3.window.size)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.coil.compose)

--- a/app/src/main/kotlin/com/donghanx/nowinmtg/MainActivity.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/MainActivity.kt
@@ -3,6 +3,8 @@ package com.donghanx.nowinmtg
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.core.view.WindowCompat
 import com.donghanx.nowinmtg.ui.NowInMtgApp
 import com.donghanx.nowinmtg.ui.theme.NowInMTGTheme
@@ -10,11 +12,14 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        setContent { NowInMTGTheme { NowInMtgApp() } }
+        setContent {
+            NowInMTGTheme { NowInMtgApp(windowSizeClass = calculateWindowSizeClass(this)) }
+        }
     }
 }

--- a/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgAppState.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgAppState.kt
@@ -1,5 +1,7 @@
 package com.donghanx.nowinmtg.ui
 
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
@@ -15,13 +17,17 @@ import com.donghanx.sets.navigation.SETS_ROUTE
 
 @Composable
 fun rememberNowInMtgAppState(
-    navController: NavHostController = rememberNavController()
-): NowInMtgAppState {
-    return remember { NowInMtgAppState(navController = navController) }
+    navController: NavHostController = rememberNavController(),
+    windowSizeClass: WindowSizeClass
+): NowInMtgAppState = remember {
+    NowInMtgAppState(navController = navController, windowSizeClass = windowSizeClass)
 }
 
 @Stable
-class NowInMtgAppState(val navController: NavHostController) {
+class NowInMtgAppState(
+    val navController: NavHostController,
+    private val windowSizeClass: WindowSizeClass
+) {
 
     val currentDestination: NavDestination?
         @Composable get() = navController.currentBackStackEntryAsState().value?.destination
@@ -42,6 +48,12 @@ class NowInMtgAppState(val navController: NavHostController) {
             TopLevelDestination.Sets,
             TopLevelDestination.Favorites
         )
+
+    val shouldShowBottomBar: Boolean
+        get() = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
+
+    val shouldShowLeftNavigationRail: Boolean
+        get() = !shouldShowBottomBar
 
     fun navigateToTopLevelDestination(route: String) {
         navController.navigate(route) {

--- a/core/design/src/main/kotlin/com/donghanx/design/ui/appbar/TopAppBar.kt
+++ b/core/design/src/main/kotlin/com/donghanx/design/ui/appbar/TopAppBar.kt
@@ -1,6 +1,9 @@
 package com.donghanx.design.ui.appbar
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -13,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -21,6 +25,7 @@ fun NowInMtgTopAppBar(
     navigationIcon: ImageVector,
     navigationIconContentDescription: String?,
     showNavigationIcon: Boolean,
+    shouldAdjustNavigationRail: Boolean,
     modifier: Modifier = Modifier,
     colors: TopAppBarColors = TopAppBarDefaults.centerAlignedTopAppBarColors(),
     onNavigationIconClick: () -> Unit = {}
@@ -29,12 +34,16 @@ fun NowInMtgTopAppBar(
         title = { Text(text = stringResource(titleResId), fontWeight = FontWeight.Bold) },
         colors = colors,
         navigationIcon = {
-            if (showNavigationIcon) {
-                IconButton(onClick = onNavigationIconClick) {
-                    Icon(
-                        imageVector = navigationIcon,
-                        contentDescription = navigationIconContentDescription
-                    )
+            Row {
+                if (showNavigationIcon) {
+                    if (shouldAdjustNavigationRail) Spacer(modifier = Modifier.width(width = 16.dp))
+
+                    IconButton(onClick = onNavigationIconClick) {
+                        Icon(
+                            imageVector = navigationIcon,
+                            contentDescription = navigationIconContentDescription
+                        )
+                    }
                 }
             }
         },

--- a/core/design/src/main/kotlin/com/donghanx/design/ui/navigation/NowInMtgNavigationBarItem.kt
+++ b/core/design/src/main/kotlin/com/donghanx/design/ui/navigation/NowInMtgNavigationBarItem.kt
@@ -2,6 +2,7 @@ package com.donghanx.design.ui.navigation
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationRailItem
 import androidx.compose.runtime.Composable
 
 @Composable
@@ -13,6 +14,22 @@ fun RowScope.NowInMtgNavigationBarItem(
     label: @Composable () -> Unit
 ) {
     NavigationBarItem(
+        selected = selected,
+        onClick = onClick,
+        icon = if (selected) selectedIcon else unSelectedIcon,
+        label = label
+    )
+}
+
+@Composable
+fun NowInMtgNavigationRailItem(
+    selected: Boolean,
+    onClick: () -> Unit,
+    selectedIcon: @Composable () -> Unit,
+    unSelectedIcon: @Composable () -> Unit,
+    label: @Composable () -> Unit
+) {
+    NavigationRailItem(
         selected = selected,
         onClick = onClick,
         icon = if (selected) selectedIcon else unSelectedIcon,

--- a/core/ui/src/main/kotlin/com/donghanx/ui/CardsGallery.kt
+++ b/core/ui/src/main/kotlin/com/donghanx/ui/CardsGallery.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import coil.size.Precision
 import com.donghanx.design.R
 import com.donghanx.design.composable.extensions.isFirstItemNotVisible
 import com.donghanx.design.composable.extensions.rippleClickable
@@ -41,7 +42,7 @@ fun CardsGallery(
         val lazyGridState = rememberLazyGridState()
 
         LazyVerticalGrid(
-            columns = GridCells.Fixed(count = 2),
+            columns = GridCells.Adaptive(minSize = 160.dp),
             state = lazyGridState,
             modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(all = 4.dp),
@@ -53,10 +54,11 @@ fun CardsGallery(
                     model =
                         ImageRequest.Builder(LocalContext.current)
                             .data(card.imageUrl)
+                            .precision(Precision.EXACT)
                             .crossfade(true)
                             .build(),
                     contentDescription = card.name,
-                    contentScale = ContentScale.Crop,
+                    contentScale = ContentScale.Fit,
                     placeholder = painterResource(id = R.drawable.blank_card_placeholder),
                     modifier =
                         Modifier.fillMaxWidth()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-animation = { module = "androidx.compose.animation:animation" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-material3-window-size = { module = "androidx.compose.material3:material3-window-size-class" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 
 # Navigation-compose


### PR DESCRIPTION
**Summary**
This PR adapts part of the app's UI to different display sizes to provide a better user experience on both mobile and large-screen tablets. More specifically:

- `CardsGallery` now utilizes adaptive GridCells so that there will be as many columns as possible and the width of each column will be at least `160.dp`.
- The app now adapts the top-level navigation UI based on Window Size classes:
    - `Compact`: Bottom NavigationBar
    - `Medium` and `Expanded`: Left Navigation Rail