### PR TITLE
Use the Multiverse ID as the unique identifier for querying cards from both the local and remote sources

### DIFF
--- a/core/data/src/main/kotlin/com/donghanx/data/repository/carddetails/CardDetailsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/carddetails/CardDetailsRepository.kt
@@ -5,7 +5,7 @@ import com.donghanx.model.CardDetails
 import kotlinx.coroutines.flow.Flow
 
 interface CardDetailsRepository {
-    fun getCardDetailsById(cardId: String): Flow<CardDetails?>
+    fun getCardDetailsById(cardId: Int): Flow<CardDetails?>
 
-    fun refreshCardDetails(cardId: String): Flow<NetworkResult<Unit>>
+    fun refreshCardDetails(cardId: Int): Flow<NetworkResult<Unit>>
 }

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/carddetails/OfflineFirstCardDetailsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/carddetails/OfflineFirstCardDetailsRepository.kt
@@ -24,10 +24,10 @@ constructor(
     private val cardsRemoteDataSource: MtgCardsRemoteDataSource,
     private val ioDispatcher: CoroutineDispatcher,
 ) : CardDetailsRepository {
-    override fun getCardDetailsById(cardId: String): Flow<CardDetails?> =
+    override fun getCardDetailsById(cardId: Int): Flow<CardDetails?> =
         cardDetailsDao.getCardDetailsById(cardId).map { it?.asExternalModel() }.flowOn(ioDispatcher)
 
-    override fun refreshCardDetails(cardId: String): Flow<NetworkResult<Unit>> =
+    override fun refreshCardDetails(cardId: Int): Flow<NetworkResult<Unit>> =
         flow { emit(cardsRemoteDataSource.getCardDetailsById(cardId)) }
             .asResultFlow()
             .foldResult(

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/cards/OfflineFirstRandomCardsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/cards/OfflineFirstRandomCardsRepository.kt
@@ -37,11 +37,10 @@ constructor(
             .asResultFlow()
             .foldResult(
                 onSuccess = { randomCards ->
-                    randomCards
-                        .syncWith(
-                            entityConverter = NetworkCard::asRandomCardEntity,
-                            modelActions = randomCardsDao::deleteAllAndInsertRandomCards,
-                        )
+                    randomCards.syncWith(
+                        entityConverter = NetworkCard::asRandomCardEntity,
+                        modelActions = randomCardsDao::deleteAllAndInsertRandomCards,
+                    )
 
                     NetworkResult.Success(Unit)
                 },

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/cards/OfflineFirstRandomCardsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/cards/OfflineFirstRandomCardsRepository.kt
@@ -32,13 +32,12 @@ constructor(
             .map { it.map(RandomCardEntity::asExternalModel) }
             .flowOn(ioDispatcher)
 
-    override fun refreshRandomCards(shouldContainImageUrl: Boolean): Flow<NetworkResult<Unit>> =
+    override fun refreshRandomCards(): Flow<NetworkResult<Unit>> =
         flow { emit(cardsRemoteDataSource.getRandomCards()) }
             .asResultFlow()
             .foldResult(
                 onSuccess = { randomCards ->
                     randomCards
-                        .filterNot { shouldContainImageUrl && it.imageUrl == null }
                         .syncWith(
                             entityConverter = NetworkCard::asRandomCardEntity,
                             modelActions = randomCardsDao::deleteAllAndInsertRandomCards,

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/cards/RandomCardsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/cards/RandomCardsRepository.kt
@@ -8,7 +8,7 @@ interface RandomCardsRepository {
 
     fun getRandomCards(): Flow<List<CardPreview>>
 
-    fun refreshRandomCards(shouldContainImageUrl: Boolean): Flow<NetworkResult<Unit>>
+    fun refreshRandomCards(): Flow<NetworkResult<Unit>>
 
     suspend fun shouldFetchInitialCards(): Boolean
 }

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/favorites/FavoritesRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/favorites/FavoritesRepository.kt
@@ -10,5 +10,5 @@ interface FavoritesRepository {
 
     suspend fun favoriteCardOrUndo(cardDetails: CardDetails)
 
-    fun observeIsCardFavorite(cardId: String): Flow<Boolean>
+    fun observeIsCardFavorite(cardId: Int): Flow<Boolean>
 }

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/favorites/OfflineFirstFavoritesRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/favorites/OfflineFirstFavoritesRepository.kt
@@ -30,7 +30,7 @@ constructor(
         withContext(ioDispatcher) {
             val favoriteCardEntity = cardDetails.asFavoriteCardEntity()
             with(favoritesDao) {
-                if (isCardFavorite(favoriteCardEntity.id)) {
+                if (isCardFavorite(favoriteCardEntity.multiverseId)) {
                     deleteFavoriteCard(favoriteCardEntity)
                 } else {
                     upsertFavoriteCard(favoriteCardEntity)
@@ -39,6 +39,6 @@ constructor(
         }
     }
 
-    override fun observeIsCardFavorite(cardId: String): Flow<Boolean> =
+    override fun observeIsCardFavorite(cardId: Int): Flow<Boolean> =
         favoritesDao.observeIsCardFavorite(cardId)
 }

--- a/core/database/src/main/kotlin/com/donghanx/database/CardsDetailsDao.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/CardsDetailsDao.kt
@@ -10,6 +10,6 @@ import kotlinx.coroutines.flow.Flow
 interface CardDetailsDao {
     @Upsert suspend fun upsertCardDetails(cardDetails: CardDetailsEntity)
 
-    @Query("SELECT * FROM card_details WHERE id = :cardId ")
-    fun getCardDetailsById(cardId: String): Flow<CardDetailsEntity?>
+    @Query("SELECT * FROM card_details WHERE multiverseId = :cardId ")
+    fun getCardDetailsById(cardId: Int): Flow<CardDetailsEntity?>
 }

--- a/core/database/src/main/kotlin/com/donghanx/database/FavoritesDao.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/FavoritesDao.kt
@@ -16,9 +16,9 @@ interface FavoritesDao {
 
     @Delete suspend fun deleteFavoriteCard(favoriteCardEntity: FavoriteCardEntity)
 
-    @Query("SELECT EXISTS(SELECT * FROM favorite_card WHERE id = :cardId)")
-    fun observeIsCardFavorite(cardId: String): Flow<Boolean>
+    @Query("SELECT EXISTS(SELECT * FROM favorite_card WHERE multiverseId = :cardId)")
+    fun observeIsCardFavorite(cardId: Int): Flow<Boolean>
 
-    @Query("SELECT EXISTS(SELECT * FROM favorite_card WHERE id = :cardId)")
-    suspend fun isCardFavorite(cardId: String): Boolean
+    @Query("SELECT EXISTS(SELECT * FROM favorite_card WHERE multiverseId = :cardId)")
+    suspend fun isCardFavorite(cardId: Int): Boolean
 }

--- a/core/database/src/main/kotlin/com/donghanx/database/NimDatabase.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/NimDatabase.kt
@@ -18,7 +18,7 @@ import com.donghanx.database.model.SetEntity
             SetEntity::class,
             FavoriteCardEntity::class,
         ],
-    version = 1,
+    version = 2,
 )
 @TypeConverters(StringListTypeConverters::class, RulingsConverter::class)
 abstract class NimDatabase : RoomDatabase() {

--- a/core/database/src/main/kotlin/com/donghanx/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/di/DatabaseModule.kt
@@ -15,6 +15,6 @@ import javax.inject.Singleton
 object DatabaseModule {
     @Provides
     @Singleton
-    fun providesNiaDatabase(@ApplicationContext applicationContext: Context): NimDatabase =
-        Room.databaseBuilder(applicationContext, NimDatabase::class.java, "nia-database").build()
+    fun providesNimDatabase(@ApplicationContext applicationContext: Context): NimDatabase =
+        Room.databaseBuilder(applicationContext, NimDatabase::class.java, "nim-database").build()
 }

--- a/core/database/src/main/kotlin/com/donghanx/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/di/DatabaseModule.kt
@@ -16,5 +16,7 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun providesNimDatabase(@ApplicationContext applicationContext: Context): NimDatabase =
-        Room.databaseBuilder(applicationContext, NimDatabase::class.java, "nim-database").build()
+        Room.databaseBuilder(applicationContext, NimDatabase::class.java, "nim-database")
+            .fallbackToDestructiveMigration()
+            .build()
 }

--- a/core/database/src/main/kotlin/com/donghanx/database/model/CardDetailsEntity.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/model/CardDetailsEntity.kt
@@ -8,8 +8,7 @@ import com.donghanx.model.network.Ruling
 
 @Entity(tableName = "card_details")
 data class CardDetailsEntity(
-    @PrimaryKey val id: String,
-    val multiverseId: String?,
+    @PrimaryKey val multiverseId: Int,
     val artist: String?,
     val cmc: Double,
     val colorIdentity: List<String>?,
@@ -39,7 +38,6 @@ data class CardDetailsEntity(
 
 fun NetworkCardDetails.asCardDetailsEntity(): CardDetailsEntity =
     CardDetailsEntity(
-        id = id,
         multiverseId = multiverseId,
         artist = artist,
         cmc = cmc,
@@ -70,8 +68,7 @@ fun NetworkCardDetails.asCardDetailsEntity(): CardDetailsEntity =
 
 fun CardDetailsEntity.asExternalModel(): CardDetails =
     CardDetails(
-        id = id,
-        multiverseId = id,
+        multiverseId = multiverseId,
         artist = artist,
         cmc = cmc,
         colorIdentity = colorIdentity,

--- a/core/database/src/main/kotlin/com/donghanx/database/model/FavoriteCardEntity.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/model/FavoriteCardEntity.kt
@@ -15,7 +15,13 @@ data class FavoriteCardEntity(
 )
 
 fun CardDetails.asFavoriteCardEntity(): FavoriteCardEntity =
-    FavoriteCardEntity(multiverseId = multiverseId, name = name, imageUrl = imageUrl, set = set, setName = setName)
+    FavoriteCardEntity(
+        multiverseId = multiverseId,
+        name = name,
+        imageUrl = imageUrl,
+        set = set,
+        setName = setName,
+    )
 
 fun FavoriteCardEntity.asExternalModel(): CardPreview =
     CardPreview(id = multiverseId, name = name, imageUrl = imageUrl)

--- a/core/database/src/main/kotlin/com/donghanx/database/model/FavoriteCardEntity.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/model/FavoriteCardEntity.kt
@@ -7,7 +7,7 @@ import com.donghanx.model.CardPreview
 
 @Entity(tableName = "favorite_card")
 data class FavoriteCardEntity(
-    @PrimaryKey val id: String,
+    @PrimaryKey val multiverseId: Int,
     val name: String,
     val imageUrl: String?,
     val set: String,
@@ -15,7 +15,7 @@ data class FavoriteCardEntity(
 )
 
 fun CardDetails.asFavoriteCardEntity(): FavoriteCardEntity =
-    FavoriteCardEntity(id = id, name = name, imageUrl = imageUrl, set = set, setName = setName)
+    FavoriteCardEntity(multiverseId = multiverseId, name = name, imageUrl = imageUrl, set = set, setName = setName)
 
 fun FavoriteCardEntity.asExternalModel(): CardPreview =
-    CardPreview(id = id, name = name, imageUrl = imageUrl)
+    CardPreview(id = multiverseId, name = name, imageUrl = imageUrl)

--- a/core/database/src/main/kotlin/com/donghanx/database/model/RandomCardEntity.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/model/RandomCardEntity.kt
@@ -7,14 +7,19 @@ import com.donghanx.model.network.NetworkCard
 
 @Entity(tableName = "random_cards")
 data class RandomCardEntity(
-    @PrimaryKey val id: String,
+    @PrimaryKey val multiverseId: Int,
     val name: String,
     val imageUrl: String?,
     val types: List<String>?,
 )
 
 fun NetworkCard.asRandomCardEntity(): RandomCardEntity =
-    RandomCardEntity(id = id, name = name, imageUrl = imageUrl, types = types)
+    RandomCardEntity(
+        multiverseId = multiverseId,
+        name = name,
+        imageUrl = imageUrl,
+        types = types,
+    )
 
 fun RandomCardEntity.asExternalModel(): CardPreview =
-    CardPreview(id = id, name = name, imageUrl = imageUrl)
+    CardPreview(id = multiverseId, name = name, imageUrl = imageUrl)

--- a/core/database/src/main/kotlin/com/donghanx/database/model/RandomCardEntity.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/model/RandomCardEntity.kt
@@ -14,12 +14,7 @@ data class RandomCardEntity(
 )
 
 fun NetworkCard.asRandomCardEntity(): RandomCardEntity =
-    RandomCardEntity(
-        multiverseId = multiverseId,
-        name = name,
-        imageUrl = imageUrl,
-        types = types,
-    )
+    RandomCardEntity(multiverseId = multiverseId, name = name, imageUrl = imageUrl, types = types)
 
 fun RandomCardEntity.asExternalModel(): CardPreview =
     CardPreview(id = multiverseId, name = name, imageUrl = imageUrl)

--- a/core/model/src/main/kotlin/com/donghanx/mock/MockUtils.kt
+++ b/core/model/src/main/kotlin/com/donghanx/mock/MockUtils.kt
@@ -6,10 +6,11 @@ import com.donghanx.model.SetInfo
 import com.donghanx.model.network.Ruling
 
 object MockUtils {
-    val emptyCards = List(5) { CardPreview(id = it.toString(), name = "", imageUrl = "") }
+    val emptyCards = List(5) { CardPreview(id = it, name = "", imageUrl = "") }
 
     val cardDetailsAvacyn: CardDetails =
         CardDetails(
+            multiverseId = 409741,
             name = "Archangel Avacyn",
             manaCost = "{3}{W}{W}",
             cmc = 5.0,
@@ -28,7 +29,6 @@ object MockUtils {
             power = "4",
             toughness = "4",
             layout = "double-faced",
-            multiverseId = "409741",
             imageUrl =
                 "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=409741&type=card",
             rulings =
@@ -87,7 +87,6 @@ object MockUtils {
             originalText =
                 "Flash\nFlying, vigilance\nWhen Archangel Avacyn enters the battlefield, creatures you control gain indestructible until end of turn.\nWhen a non-Angel creature you control dies, transform Archangel Avacyn at the beginning of the next upkeep.",
             originalType = "Legendary Creature — Angel",
-            id = "ad53597a-4448-5cbd-82bf-11d163b0c14f",
             flavor = null,
             setName = "Shadows over Innistrad",
             variations = null,
@@ -95,6 +94,7 @@ object MockUtils {
 
     val cardDetailsIncomplete: CardDetails =
         CardDetails(
+            multiverseId = 409741,
             name = "",
             manaCost = null,
             cmc = 5.0,
@@ -112,12 +112,10 @@ object MockUtils {
             power = null,
             toughness = null,
             layout = "double-faced",
-            multiverseId = null,
             imageUrl = null,
             printings = listOf("SOI"),
             originalText = null,
             originalType = null,
-            id = "ad53597a-4448-5cbd-82bf-11d163b0c14f",
             flavor = null,
             setName = "Shadows over Innistrad",
             variations = null,

--- a/core/model/src/main/kotlin/com/donghanx/model/CardDetails.kt
+++ b/core/model/src/main/kotlin/com/donghanx/model/CardDetails.kt
@@ -3,8 +3,7 @@ package com.donghanx.model
 import com.donghanx.model.network.Ruling
 
 data class CardDetails(
-    val id: String,
-    val multiverseId: String?,
+    val multiverseId: Int,
     val artist: String?,
     val cmc: Double,
     val colorIdentity: List<String>?,

--- a/core/model/src/main/kotlin/com/donghanx/model/CardPreview.kt
+++ b/core/model/src/main/kotlin/com/donghanx/model/CardPreview.kt
@@ -1,3 +1,3 @@
 package com.donghanx.model
 
-data class CardPreview(val id: String, val name: String, val imageUrl: String?)
+data class CardPreview(val id: Int, val name: String, val imageUrl: String?)

--- a/core/model/src/main/kotlin/com/donghanx/model/network/NetworkCardDetails.kt
+++ b/core/model/src/main/kotlin/com/donghanx/model/network/NetworkCardDetails.kt
@@ -4,11 +4,11 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class NetworkCardDetailsList(@SerialName("cards") val cards: List<NetworkCardDetails>)
+data class NetworkCardDetailsResponse(@SerialName("card") val card: NetworkCardDetails)
 
 @Serializable
 data class NetworkCardDetails(
-    @SerialName("id") val id: String,
+    @SerialName("multiverseid") val multiverseId: Int,
     @SerialName("artist") val artist: String?,
     @SerialName("cmc") val cmc: Double,
     @SerialName("colorIdentity") val colorIdentity: List<String>?,
@@ -17,7 +17,6 @@ data class NetworkCardDetails(
     @SerialName("imageUrl") val imageUrl: String?,
     @SerialName("layout") val layout: String,
     @SerialName("manaCost") val manaCost: String?,
-    @SerialName("multiverseid") val multiverseId: String?,
     @SerialName("name") val name: String,
     @SerialName("number") val number: String,
     @SerialName("originalText") val originalText: String?,

--- a/core/model/src/main/kotlin/com/donghanx/model/network/NetworkCards.kt
+++ b/core/model/src/main/kotlin/com/donghanx/model/network/NetworkCards.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class NetworkCard(
-    @SerialName("id") val id: String,
     @SerialName("multiverseid") val multiverseId: Int,
     @SerialName("name") val name: String,
     @SerialName("imageUrl") val imageUrl: String,

--- a/core/model/src/main/kotlin/com/donghanx/model/network/NetworkCards.kt
+++ b/core/model/src/main/kotlin/com/donghanx/model/network/NetworkCards.kt
@@ -8,8 +8,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class NetworkCard(
     @SerialName("id") val id: String,
+    @SerialName("multiverseid") val multiverseId: Int,
     @SerialName("name") val name: String,
-    @SerialName("imageUrl") val imageUrl: String?,
+    @SerialName("imageUrl") val imageUrl: String,
     @SerialName("text") val text: String?,
     @SerialName("Types") val types: List<String>?,
 )

--- a/core/network/src/main/kotlin/com/donghanx/network/MtgCardsRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/donghanx/network/MtgCardsRemoteDataSource.kt
@@ -9,6 +9,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.url
+import io.ktor.http.parameters
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -20,6 +21,8 @@ class MtgCardsRemoteDataSource @Inject constructor(private val mtgHttpClient: Mt
             .get {
                 url(path = "/cards")
                 parameter(key = "random", value = true)
+                parameter(key = "contains", value = "multiverseId")
+                parameter(key = "contains", value = "imageUrl")
                 parameter(key = "pageSize", value = pageSize)
             }
             .body<NetworkCards>()

--- a/core/network/src/main/kotlin/com/donghanx/network/MtgCardsRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/donghanx/network/MtgCardsRemoteDataSource.kt
@@ -2,14 +2,13 @@ package com.donghanx.network
 
 import com.donghanx.model.network.NetworkCard
 import com.donghanx.model.network.NetworkCardDetails
-import com.donghanx.model.network.NetworkCardDetailsList
+import com.donghanx.model.network.NetworkCardDetailsResponse
 import com.donghanx.model.network.NetworkCards
 import com.donghanx.network.client.MtgHttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.url
-import io.ktor.http.parameters
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -28,13 +27,6 @@ class MtgCardsRemoteDataSource @Inject constructor(private val mtgHttpClient: Mt
             .body<NetworkCards>()
             .cards
 
-    suspend fun getCardDetailsById(cardId: String): NetworkCardDetails =
-        mtgHttpClient()
-            .get {
-                url(path = "/cards")
-                parameter(key = "id", value = cardId)
-            }
-            .body<NetworkCardDetailsList>()
-            .cards
-            .first()
+    suspend fun getCardDetailsById(cardId: Int): NetworkCardDetails =
+        mtgHttpClient().get { url(path = "/cards/$cardId") }.body<NetworkCardDetailsResponse>().card
 }

--- a/core/ui/src/main/kotlin/com/donghanx/ui/CardsGallery.kt
+++ b/core/ui/src/main/kotlin/com/donghanx/ui/CardsGallery.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun CardsGallery(
     cards: List<CardPreview>,
-    onCardClick: (cardId: String) -> Unit,
+    onCardClick: (cardId: Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {

--- a/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/CardDetailsViewModel.kt
+++ b/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/CardDetailsViewModel.kt
@@ -35,10 +35,10 @@ constructor(
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    private val cardId: StateFlow<String?> =
+    private val cardId: StateFlow<Int?> =
         savedStateHandle.getStateFlow(key = CARD_ID_ARGS, initialValue = null)
 
-    private val validCardId: Flow<String> = cardId.filterNotNull()
+    private val validCardId: Flow<Int> = cardId.filterNotNull()
 
     private val viewModelState = MutableStateFlow(CardDetailsViewModelState(refreshing = true))
 

--- a/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/navigation/CardDetailsNavigation.kt
+++ b/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/navigation/CardDetailsNavigation.kt
@@ -7,13 +7,15 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.donghanx.carddetails.CardDetailsScreen
 
 const val CARD_DETAILS_ROUTE = "CardDetails"
 internal const val CARD_ID_ARGS = "CardId"
 
-fun NavController.navigateToCardDetails(cardId: String, parentRoute: String) {
+fun NavController.navigateToCardDetails(cardId: Int, parentRoute: String) {
     navigate(route = "${cardDetailsRoute(parentRoute)}/$cardId") { launchSingleTop = true }
 }
 
@@ -24,6 +26,7 @@ fun NavGraphBuilder.cardDetailsScreen(
 ) {
     composable(
         route = "${cardDetailsRoute(parentRoute)}/{$CARD_ID_ARGS}",
+        arguments = listOf(navArgument(CARD_ID_ARGS) { type = NavType.IntType }),
         enterTransition = {
             fadeIn(animationSpec = tween(durationMillis = 300, easing = LinearEasing)) +
                 slideIntoContainer(towards = AnimatedContentTransitionScope.SlideDirection.Start)

--- a/feature/favorites/src/main/kotlin/com/donghanx/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/main/kotlin/com/donghanx/favorites/FavoritesScreen.kt
@@ -9,7 +9,7 @@ import com.donghanx.ui.CardsGallery
 
 @Composable
 internal fun FavoritesScreen(
-    onCardClick: (cardId: String) -> Unit,
+    onCardClick: (cardId: Int) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: FavoritesViewModel = hiltViewModel(),
 ) {

--- a/feature/favorites/src/main/kotlin/com/donghanx/favorites/navigation/FavoritesNavigation.kt
+++ b/feature/favorites/src/main/kotlin/com/donghanx/favorites/navigation/FavoritesNavigation.kt
@@ -9,7 +9,7 @@ const val FAVORITES_GRAPH_ROUTE = "FavoritesGraph"
 const val FAVORITES_ROUTE = "Favorites"
 
 fun NavGraphBuilder.favoriteGraph(
-    onCardClick: (cardId: String, parentRoute: String) -> Unit,
+    onCardClick: (cardId: Int, parentRoute: String) -> Unit,
     nestedGraphs: NavGraphBuilder.(parentRoute: String) -> Unit,
 ) {
     navigation(startDestination = FAVORITES_ROUTE, route = FAVORITES_GRAPH_ROUTE) {

--- a/feature/randomcards/src/main/kotlin/com/donghanx/randomcards/RancomCardsScreen.kt
+++ b/feature/randomcards/src/main/kotlin/com/donghanx/randomcards/RancomCardsScreen.kt
@@ -18,7 +18,7 @@ import com.donghanx.ui.CardsGallery
 
 @Composable
 internal fun RandomCardsScreen(
-    onCardClick: (cardId: String) -> Unit,
+    onCardClick: (cardId: Int) -> Unit,
     onShowSnackbar: suspend (message: String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: RandomCardsViewModel = hiltViewModel(),

--- a/feature/randomcards/src/main/kotlin/com/donghanx/randomcards/RandomCardsViewModel.kt
+++ b/feature/randomcards/src/main/kotlin/com/donghanx/randomcards/RandomCardsViewModel.kt
@@ -51,7 +51,7 @@ constructor(private val randomCardsRepository: RandomCardsRepository) : ViewMode
 
         viewModelScope.launch {
             randomCardsRepository
-                .refreshRandomCards(shouldContainImageUrl = true)
+                .refreshRandomCards()
                 .onEach { it.updateViewModelState() }
                 .collect()
         }

--- a/feature/randomcards/src/main/kotlin/com/donghanx/randomcards/navigation/RandomCardsNavigation.kt
+++ b/feature/randomcards/src/main/kotlin/com/donghanx/randomcards/navigation/RandomCardsNavigation.kt
@@ -9,7 +9,7 @@ const val RANDOM_CARDS_GRAPH_ROUTE = "RandomCardsGraph"
 const val RANDOM_CARDS_ROUTE = "RandomCards"
 
 fun NavGraphBuilder.randomCardsGraph(
-    onCardClick: (cardId: String, parentRoute: String) -> Unit,
+    onCardClick: (cardId: Int, parentRoute: String) -> Unit,
     nestedGraphs: NavGraphBuilder.(parentRoute: String) -> Unit,
     onShowSnackbar: suspend (message: String) -> Unit,
 ) {


### PR DESCRIPTION
**Summary**
Previously, we used two separate remote API sources for querying cards and sets, each with its own method for defining a unique card ID. To enable joint queries, such as fetching cards from a specific set, we will standardize on the Multiverse ID. This ID is unique to each printing of a card (which is determined by the Wizards) and will allow us to link data across both sources effectively.

This PR implements the following changes to fully support the use of Multiverse ID:
- Modify the query parameter for fetching random cards to ensure all cards include a valid Multiverse ID.
- Use the Multiverse ID as the primary key in the following database tables: `random_cards`, `card_details`, and `favorites`.

These changes lay the groundwork for subsequent PRs that add Set Details screen which includes joint querying between the two remote sources.