### PR TITLE
Implement SetDetails feature

### DIFF
--- a/app/src/main/kotlin/com/donghanx/nowinmtg/navigation/NimNavHost.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/navigation/NimNavHost.kt
@@ -18,6 +18,7 @@ import com.donghanx.design.composable.provider.LocalSharedTransitionScope
 import com.donghanx.favorites.navigation.favoriteGraph
 import com.donghanx.randomcards.navigation.RANDOM_CARDS_GRAPH_ROUTE
 import com.donghanx.randomcards.navigation.randomCardsGraph
+import com.donghanx.search.navigation.SEARCH_ROUTE
 import com.donghanx.search.navigation.searchScreen
 import com.donghanx.setdetails.navigation.navigateToSetDetails
 import com.donghanx.setdetails.navigation.setDetailsScreen
@@ -58,6 +59,7 @@ fun NimNavHost(
                         )
                     },
                 )
+
                 setsScreen(
                     onShowSnackbar = onShowSnackbar,
                     onSetClick = { setInfo ->
@@ -70,10 +72,29 @@ fun NimNavHost(
                         setDetailsScreen(
                             parentRoute = parentRoute,
                             onBackClick = navController::popBackStack,
+                            onCardClick = { card ->
+                                // TODO: navigate to SetDetails screen
+                            },
+                        )
+
+                        cardDetailsScreen(
+                            parentRoute = parentRoute,
+                            onBackClick = navController::popBackStack,
+                            onShowSnackbar = onShowSnackbar,
                         )
                     },
                 )
-                searchScreen(onCloseClick = navController::popBackStack)
+
+                searchScreen(
+                    onCloseClick = navController::popBackStack,
+                    onSetClick = { setInfo ->
+                        navController.navigateToSetDetails(
+                            setId = setInfo.scryfallId,
+                            parentRoute = SEARCH_ROUTE,
+                        )
+                    },
+                )
+
                 favoriteGraph(
                     onCardClick = { card, parentRoute ->
                         navController.navigateToCardDetails(
@@ -83,6 +104,7 @@ fun NimNavHost(
                         )
                     },
                     nestedGraphs = { parentRoute ->
+                        // TODO: use a centrailized shared CardDetailsScreen nav composable
                         cardDetailsScreen(
                             parentRoute = parentRoute,
                             onBackClick = navController::popBackStack,

--- a/app/src/main/kotlin/com/donghanx/nowinmtg/navigation/NimNavHost.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/navigation/NimNavHost.kt
@@ -62,11 +62,16 @@ fun NimNavHost(
                     onShowSnackbar = onShowSnackbar,
                     onSetClick = { setInfo ->
                         navController.navigateToSetDetails(
-                            code = setInfo.code,
+                            setId = setInfo.scryfallId,
                             parentRoute = SETS_ROUTE,
                         )
                     },
-                    nestedGraphs = { parentRoute -> setDetailsScreen(parentRoute = parentRoute) },
+                    nestedGraphs = { parentRoute ->
+                        setDetailsScreen(
+                            parentRoute = parentRoute,
+                            onBackClick = navController::popBackStack,
+                        )
+                    },
                 )
                 searchScreen(onCloseClick = navController::popBackStack)
                 favoriteGraph(

--- a/core/data/src/main/kotlin/com/donghanx/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/di/DataModule.kt
@@ -6,6 +6,8 @@ import com.donghanx.data.repository.cards.OfflineFirstRandomCardsRepository
 import com.donghanx.data.repository.cards.RandomCardsRepository
 import com.donghanx.data.repository.favorites.FavoritesRepository
 import com.donghanx.data.repository.favorites.OfflineFirstFavoritesRepository
+import com.donghanx.data.repository.setdetails.OfflineFirstSetDetailsRepository
+import com.donghanx.data.repository.setdetails.SetDetailsRepository
 import com.donghanx.data.repository.sets.OfflineFirstSetsRepository
 import com.donghanx.data.repository.sets.SetsRepository
 import dagger.Binds
@@ -34,4 +36,9 @@ interface DataModule {
     fun bindFavoritesRepository(
         offlineFirstFavoritesRepository: OfflineFirstFavoritesRepository
     ): FavoritesRepository
+
+    @Binds
+    fun bindSetDetailsRepository(
+        offlineFirstSetDetailsRepository: OfflineFirstSetDetailsRepository
+    ): SetDetailsRepository
 }

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/OfflineFirstSetDetailsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/OfflineFirstSetDetailsRepository.kt
@@ -1,3 +1,49 @@
 package com.donghanx.data.repository.setdetails
 
-class OfflineFirstSetDetailsRepository {}
+import com.donghanx.common.NetworkResult
+import com.donghanx.common.asResultFlow
+import com.donghanx.common.foldResult
+import com.donghanx.data.sync.syncListWith
+import com.donghanx.database.CardDetailsDao
+import com.donghanx.database.model.CardDetailsEntity
+import com.donghanx.database.model.asCardDetailsEntity
+import com.donghanx.database.model.asExternalModel
+import com.donghanx.model.CardDetails
+import com.donghanx.model.network.NetworkCardDetails
+import com.donghanx.network.SetsRemoteDataSource
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+
+class OfflineFirstSetDetailsRepository
+@Inject
+constructor(
+    private val setsRemoteDataSource: SetsRemoteDataSource,
+    private val cardDetailsDao: CardDetailsDao,
+    private val ioDispatcher: CoroutineDispatcher,
+) : SetDetailsRepository {
+
+    override fun refreshCardsInCurrentSet(searchUri: String): Flow<NetworkResult<Unit>> =
+        flow { emit(setsRemoteDataSource.getCardsInCurrentSet(searchUri)) }
+            .asResultFlow()
+            .foldResult(
+                onSuccess = { cards ->
+                    cards.syncListWith(
+                        entityConverter = NetworkCardDetails::asCardDetailsEntity,
+                        modelActions = cardDetailsDao::upsertCardDetailsList,
+                    )
+                    NetworkResult.Success(Unit)
+                },
+                onError = { NetworkResult.Error(it) },
+            )
+            .flowOn(ioDispatcher)
+
+    override fun getCardsInCurrentSet(setCode: String): Flow<List<CardDetails>> =
+        cardDetailsDao
+            .getCardDetailsListBySetCode(setCode)
+            .map { it.map(CardDetailsEntity::asExternalModel) }
+            .flowOn(ioDispatcher)
+}

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/OfflineFirstSetDetailsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/OfflineFirstSetDetailsRepository.kt
@@ -7,9 +7,7 @@ import com.donghanx.data.sync.syncListWith
 import com.donghanx.database.CardDetailsDao
 import com.donghanx.database.model.CardDetailsEntity
 import com.donghanx.database.model.asCardDetailsEntity
-import com.donghanx.database.model.asExternalModel
 import com.donghanx.database.model.asExternalPreviewModel
-import com.donghanx.model.CardDetails
 import com.donghanx.model.CardPreview
 import com.donghanx.model.network.NetworkCardDetails
 import com.donghanx.network.SetsRemoteDataSource

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/OfflineFirstSetDetailsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/OfflineFirstSetDetailsRepository.kt
@@ -1,0 +1,3 @@
+package com.donghanx.data.repository.setdetails
+
+class OfflineFirstSetDetailsRepository {}

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/SetDetailsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/SetDetailsRepository.kt
@@ -1,7 +1,6 @@
 package com.donghanx.data.repository.setdetails
 
 import com.donghanx.common.NetworkResult
-import com.donghanx.model.CardDetails
 import com.donghanx.model.CardPreview
 import kotlinx.coroutines.flow.Flow
 

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/SetDetailsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/SetDetailsRepository.kt
@@ -1,3 +1,6 @@
 package com.donghanx.data.repository.setdetails
 
-interface SetDetailsRepository {}
+interface SetDetailsRepository {
+
+
+}

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/SetDetailsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/SetDetailsRepository.kt
@@ -1,6 +1,12 @@
 package com.donghanx.data.repository.setdetails
 
+import com.donghanx.common.NetworkResult
+import com.donghanx.model.CardDetails
+import kotlinx.coroutines.flow.Flow
+
 interface SetDetailsRepository {
 
+    fun refreshCardsInCurrentSet(searchUri: String): Flow<NetworkResult<Unit>>
 
+    fun getCardsInCurrentSet(setCode: String): Flow<List<CardDetails>>
 }

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/SetDetailsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/SetDetailsRepository.kt
@@ -1,0 +1,3 @@
+package com.donghanx.data.repository.setdetails
+
+interface SetDetailsRepository {}

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/SetDetailsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/setdetails/SetDetailsRepository.kt
@@ -2,11 +2,12 @@ package com.donghanx.data.repository.setdetails
 
 import com.donghanx.common.NetworkResult
 import com.donghanx.model.CardDetails
+import com.donghanx.model.CardPreview
 import kotlinx.coroutines.flow.Flow
 
 interface SetDetailsRepository {
 
     fun refreshCardsInCurrentSet(searchUri: String): Flow<NetworkResult<Unit>>
 
-    fun getCardsInCurrentSet(setCode: String): Flow<List<CardDetails>>
+    fun getCardsInCurrentSet(setCode: String): Flow<List<CardPreview>>
 }

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/sets/OfflineFirstSetsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/sets/OfflineFirstSetsRepository.kt
@@ -52,6 +52,9 @@ constructor(
             .map { it.map(SetEntity::asExternalModel) }
             .flowOn(ioDispatcher)
 
+    override fun getSetInfoById(id: String): Flow<SetInfo> =
+        setsDao.getSetById(id).map(SetEntity::asExternalModel)
+
     override suspend fun shouldFetchInitialSets(): Boolean {
         return withContext(ioDispatcher) { setsDao.getSetsCount() == 0 }
     }

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/sets/OfflineFirstSetsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/sets/OfflineFirstSetsRepository.kt
@@ -53,7 +53,7 @@ constructor(
             .flowOn(ioDispatcher)
 
     override fun getSetInfoById(id: String): Flow<SetInfo> =
-        setsDao.getSetById(id).map(SetEntity::asExternalModel)
+        setsDao.getSetById(id).map(SetEntity::asExternalModel).flowOn(ioDispatcher)
 
     override suspend fun shouldFetchInitialSets(): Boolean {
         return withContext(ioDispatcher) { setsDao.getSetsCount() == 0 }

--- a/core/data/src/main/kotlin/com/donghanx/data/repository/sets/SetsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/sets/SetsRepository.kt
@@ -12,5 +12,7 @@ interface SetsRepository {
 
     fun searchAllSetsByQuery(query: String): Flow<List<SetInfo>>
 
+    fun getSetInfoById(id: String): Flow<SetInfo>
+
     suspend fun shouldFetchInitialSets(): Boolean
 }

--- a/core/database/src/main/kotlin/com/donghanx/database/CardsDetailsDao.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/CardsDetailsDao.kt
@@ -10,8 +10,13 @@ import kotlinx.coroutines.flow.Flow
 interface CardDetailsDao {
     @Upsert suspend fun upsertCardDetails(cardDetails: CardDetailsEntity)
 
+    @Upsert suspend fun upsertCardDetailsList(cardDetailsCollection: List<CardDetailsEntity>)
+
     @Query("SELECT * FROM card_details WHERE id = :cardId ")
     fun getCardDetailsById(cardId: String): Flow<CardDetailsEntity?>
+
+    @Query("SELECT * FROM card_details WHERE `set` = :setCode ")
+    fun getCardDetailsListBySetCode(setCode: String): Flow<List<CardDetailsEntity>>
 
     @Query("SELECT * FROM card_details WHERE multiverseId = :multiverseId ")
     fun getCardDetailsByMultiverseId(multiverseId: Int): Flow<CardDetailsEntity?>

--- a/core/database/src/main/kotlin/com/donghanx/database/SetsDao.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/SetsDao.kt
@@ -19,4 +19,6 @@ interface SetsDao {
     fun searchAllSetsByQuery(query: String): Flow<List<SetEntity>>
 
     @Query("SELECT COUNT(*) FROM sets") fun getSetsCount(): Int
+
+    @Query("SELECT * FROM sets WHERE scryfallId = :id") fun getSetById(id: String): Flow<SetEntity>
 }

--- a/core/database/src/main/kotlin/com/donghanx/database/model/CardDetailsEntity.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/model/CardDetailsEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.donghanx.model.CardDetails
+import com.donghanx.model.CardPreview
 import com.donghanx.model.network.ImageUris
 import com.donghanx.model.network.NetworkCardDetails
 
@@ -72,3 +73,6 @@ fun CardDetailsEntity.asExternalModel(): CardDetails =
         setName = setName,
         toughness = toughness,
     )
+
+fun CardDetailsEntity.asExternalPreviewModel(): CardPreview =
+    CardPreview(id = id, name = name, imageUrl = imageUris?.png)

--- a/core/design/src/main/kotlin/com/donghanx/design/composable/provider/LocalSharedTransitionProvider.kt
+++ b/core/design/src/main/kotlin/com/donghanx/design/composable/provider/LocalSharedTransitionProvider.kt
@@ -19,7 +19,7 @@ val ProvidableCompositionLocal<SharedTransitionScope?>.currentNotNull: SharedTra
     @Composable get() = current ?: throw IllegalStateException("No SharedTransitionScope found")
 
 val ProvidableCompositionLocal<AnimatedVisibilityScope?>.currentNotNull: AnimatedVisibilityScope
-    @Composable get() = current ?: throw IllegalStateException("No SharedTransitionScope found")
+    @Composable get() = current ?: throw IllegalStateException("No AnimatedVisibilityScope found")
 
 @Composable
 fun SharedTransitionProviderWrapper(content: @Composable () -> Unit) {

--- a/core/design/src/main/kotlin/com/donghanx/design/ui/card/ExpandableCard.kt
+++ b/core/design/src/main/kotlin/com/donghanx/design/ui/card/ExpandableCard.kt
@@ -2,7 +2,6 @@ package com.donghanx.design.ui.card
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -55,12 +54,7 @@ private fun ExpandableCard(
 ) {
     Card(
         modifier =
-            modifier.fillMaxWidth().wrapContentHeight().clickable(
-                interactionSource = MutableInteractionSource(),
-                indication = null,
-            ) {
-                onSetExpanded(!expanded)
-            }
+            modifier.fillMaxWidth().wrapContentHeight().clickable { onSetExpanded(!expanded) }
     ) {
         Column(modifier = Modifier.padding(all = 8.dp)) {
             if (showHeaderWhenExpanded || !expanded) {

--- a/core/design/src/main/kotlin/com/donghanx/design/ui/grid/FullWidthItem.kt
+++ b/core/design/src/main/kotlin/com/donghanx/design/ui/grid/FullWidthItem.kt
@@ -1,0 +1,13 @@
+package com.donghanx.design.ui.grid
+
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridScope
+import androidx.compose.runtime.Composable
+
+fun LazyGridScope.fullWidthItem(
+    key: Any? = null,
+    contentType: Any? = null,
+    content: @Composable () -> Unit,
+) {
+    item(key = key, contentType = contentType, span = { GridItemSpan(maxLineSpan) }) { content() }
+}

--- a/core/design/src/main/kotlin/com/donghanx/design/ui/text/ResizableText.kt
+++ b/core/design/src/main/kotlin/com/donghanx/design/ui/text/ResizableText.kt
@@ -1,0 +1,47 @@
+package com.donghanx.design.ui.text
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun ResizableText(
+    text: String,
+    modifier: Modifier = Modifier,
+    resizable: Boolean = true,
+    fontSize: TextUnit = 16.sp,
+    fontWeight: FontWeight = FontWeight.Normal,
+    maxLines: Int = 1,
+) {
+    var multiplier by remember { mutableFloatStateOf(1F) }
+    var readyToDraw by remember { mutableStateOf(false) }
+
+    Text(
+        text = text,
+        maxLines = maxLines,
+        fontSize = fontSize * multiplier,
+        fontWeight = fontWeight,
+        onTextLayout = {
+            if (resizable && it.hasVisualOverflow) {
+                multiplier *= 0.9F
+            } else {
+                readyToDraw = true
+            }
+        },
+        modifier =
+            modifier.drawWithContent {
+                if (readyToDraw) {
+                    drawContent()
+                }
+            },
+    )
+}

--- a/core/model/src/main/kotlin/com/donghanx/model/network/NetworkSetDetails.kt
+++ b/core/model/src/main/kotlin/com/donghanx/model/network/NetworkSetDetails.kt
@@ -1,17 +1,12 @@
 package com.donghanx.model.network
-import kotlinx.serialization.Serializable
 
 import kotlinx.serialization.SerialName
-
+import kotlinx.serialization.Serializable
 
 @Serializable
 data class NetworkSetDetails(
-    @SerialName("data")
-    val cards: List<NetworkCardDetails>,
-    @SerialName("has_more")
-    val hasMore: Boolean,
-    @SerialName("next_page")
-    val nextPage: String?,
-    @SerialName("total_cards")
-    val totalCards: Int
+    @SerialName("data") val cards: List<NetworkCardDetails>,
+    @SerialName("has_more") val hasMore: Boolean,
+    @SerialName("next_page") val nextPage: String?,
+    @SerialName("total_cards") val totalCards: Int,
 )

--- a/core/model/src/main/kotlin/com/donghanx/model/network/NetworkSetDetails.kt
+++ b/core/model/src/main/kotlin/com/donghanx/model/network/NetworkSetDetails.kt
@@ -1,0 +1,17 @@
+package com.donghanx.model.network
+import kotlinx.serialization.Serializable
+
+import kotlinx.serialization.SerialName
+
+
+@Serializable
+data class NetworkSetDetails(
+    @SerialName("data")
+    val cards: List<NetworkCardDetails>,
+    @SerialName("has_more")
+    val hasMore: Boolean,
+    @SerialName("next_page")
+    val nextPage: String,
+    @SerialName("total_cards")
+    val totalCards: Int
+)

--- a/core/model/src/main/kotlin/com/donghanx/model/network/NetworkSetDetails.kt
+++ b/core/model/src/main/kotlin/com/donghanx/model/network/NetworkSetDetails.kt
@@ -11,7 +11,7 @@ data class NetworkSetDetails(
     @SerialName("has_more")
     val hasMore: Boolean,
     @SerialName("next_page")
-    val nextPage: String,
+    val nextPage: String?,
     @SerialName("total_cards")
     val totalCards: Int
 )

--- a/core/network/src/main/kotlin/com/donghanx/network/SetsRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/donghanx/network/SetsRemoteDataSource.kt
@@ -1,6 +1,5 @@
 package com.donghanx.network
 
-import com.donghanx.model.network.NetworkCardDetails
 import com.donghanx.model.network.NetworkSet
 import com.donghanx.model.network.NetworkSetDetails
 import com.donghanx.model.network.NetworkSets
@@ -14,9 +13,8 @@ class SetsRemoteDataSource @Inject constructor(private val scryfallHttpClient: S
     suspend fun getAllSets(): List<NetworkSet> =
         scryfallHttpClient().get { url(path = "/sets") }.body<NetworkSets>().data
 
-    suspend fun getCardsInCurrentSet(searchUri: String): List<NetworkCardDetails> =
+    suspend fun getCardsInCurrentSet(searchUri: String): NetworkSetDetails =
         scryfallHttpClient()
             .get { url(urlString = searchUri.removePrefix(ScryfallHttpClient.BASE_URL)) }
             .body<NetworkSetDetails>()
-            .cards
 }

--- a/core/network/src/main/kotlin/com/donghanx/network/SetsRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/donghanx/network/SetsRemoteDataSource.kt
@@ -1,6 +1,8 @@
 package com.donghanx.network
 
+import com.donghanx.model.network.NetworkCardDetails
 import com.donghanx.model.network.NetworkSet
+import com.donghanx.model.network.NetworkSetDetails
 import com.donghanx.model.network.NetworkSets
 import com.donghanx.network.client.ScryfallHttpClient
 import io.ktor.client.call.body
@@ -11,4 +13,10 @@ import javax.inject.Inject
 class SetsRemoteDataSource @Inject constructor(private val scryfallHttpClient: ScryfallHttpClient) {
     suspend fun getAllSets(): List<NetworkSet> =
         scryfallHttpClient().get { url(path = "/sets") }.body<NetworkSets>().data
+
+    suspend fun getCardsInCurrentSet(searchUri: String): List<NetworkCardDetails> =
+        scryfallHttpClient()
+            .get { url(urlString = searchUri.removePrefix(ScryfallHttpClient.BASE_URL)) }
+            .body<NetworkSetDetails>()
+            .cards
 }

--- a/core/network/src/main/kotlin/com/donghanx/network/client/MtgHttpClient.kt
+++ b/core/network/src/main/kotlin/com/donghanx/network/client/MtgHttpClient.kt
@@ -15,4 +15,3 @@ class MtgHttpClient @Inject constructor() {
 
     private val client: HttpClient by lazy { baseHttpClient(MTG_BASE_URL) }
 }
-

--- a/core/network/src/main/kotlin/com/donghanx/network/client/MtgHttpClient.kt
+++ b/core/network/src/main/kotlin/com/donghanx/network/client/MtgHttpClient.kt
@@ -7,9 +7,12 @@ import javax.inject.Singleton
 @Singleton
 class MtgHttpClient @Inject constructor() {
 
+    companion object {
+        private const val MTG_BASE_URL = "api.magicthegathering.io/v1"
+    }
+
     operator fun invoke(): HttpClient = client
 
     private val client: HttpClient by lazy { baseHttpClient(MTG_BASE_URL) }
 }
 
-private const val MTG_BASE_URL = "api.magicthegathering.io/v1"

--- a/core/network/src/main/kotlin/com/donghanx/network/client/ScryfallHttpClient.kt
+++ b/core/network/src/main/kotlin/com/donghanx/network/client/ScryfallHttpClient.kt
@@ -5,7 +5,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class  ScryfallHttpClient @Inject constructor() {
+class ScryfallHttpClient @Inject constructor() {
 
     companion object {
         const val BASE_URL = "api.scryfall.com"
@@ -15,4 +15,3 @@ class  ScryfallHttpClient @Inject constructor() {
 
     private val client: HttpClient by lazy { baseHttpClient(BASE_URL) }
 }
-

--- a/core/network/src/main/kotlin/com/donghanx/network/client/ScryfallHttpClient.kt
+++ b/core/network/src/main/kotlin/com/donghanx/network/client/ScryfallHttpClient.kt
@@ -5,10 +5,14 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ScryfallHttpClient @Inject constructor() {
+class  ScryfallHttpClient @Inject constructor() {
+
+    companion object {
+        const val BASE_URL = "api.scryfall.com"
+    }
+
     operator fun invoke(): HttpClient = client
 
-    private val client: HttpClient by lazy { baseHttpClient(SCRYFALL_BASE_URL) }
+    private val client: HttpClient by lazy { baseHttpClient(BASE_URL) }
 }
 
-private const val SCRYFALL_BASE_URL = "api.scryfall.com"

--- a/core/ui/src/main/kotlin/com/donghanx/ui/CardsGallery.kt
+++ b/core/ui/src/main/kotlin/com/donghanx/ui/CardsGallery.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items

--- a/core/ui/src/main/kotlin/com/donghanx/ui/CardsGallery.kt
+++ b/core/ui/src/main/kotlin/com/donghanx/ui/CardsGallery.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -43,6 +45,7 @@ fun CardsGallery(
     cards: List<CardPreview>,
     onCardClick: (card: CardPreview) -> Unit,
     modifier: Modifier = Modifier,
+    header: (LazyGridScope.() -> Unit)? = null,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         val scope = rememberCoroutineScope()
@@ -56,6 +59,8 @@ fun CardsGallery(
             verticalArrangement = Arrangement.spacedBy(6.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
+            header?.invoke(this)
+
             items(cards, key = { card -> card.id }) { card ->
                 val cacheKey =
                     remember(card.id) { CardSharedElementKey(id = card.id, origin = parentRoute) }

--- a/core/ui/src/main/kotlin/com/donghanx/ui/SetInfoItem.kt
+++ b/core/ui/src/main/kotlin/com/donghanx/ui/SetInfoItem.kt
@@ -1,6 +1,7 @@
 package com.donghanx.ui
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -27,11 +28,15 @@ fun SetInfoItem(
     code: String,
     name: String,
     iconUrl: String,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
     resizable: Boolean = false,
     maxLines: Int = 1,
 ) {
-    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+    Row(
+        modifier = modifier.clickable(onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         AsyncImage(model = iconUrl, contentDescription = name, modifier = Modifier.size(24.dp))
 
         Spacer(modifier = Modifier.width(4.dp))
@@ -65,6 +70,7 @@ private fun SetInfoItemPreview() {
         code = "soi",
         name = "Shadows over Innistrad",
         iconUrl = "https://svgs.scryfall.io/sets/soi.svg?1698638400",
+        onClick = {},
     )
 }
 

--- a/core/ui/src/main/kotlin/com/donghanx/ui/SetInfoItem.kt
+++ b/core/ui/src/main/kotlin/com/donghanx/ui/SetInfoItem.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -21,17 +23,30 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 
 @Composable
-fun SetInfoItem(code: String, name: String, iconUrl: String, modifier: Modifier = Modifier) {
-    Row(
-        modifier = modifier.horizontalScroll(state = rememberScrollState()),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
+fun SetInfoItem(
+    code: String,
+    name: String,
+    iconUrl: String,
+    modifier: Modifier = Modifier,
+    resizable: Boolean = false,
+    maxLines: Int = 1,
+) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         AsyncImage(model = iconUrl, contentDescription = name, modifier = Modifier.size(24.dp))
 
-        Text(text = name, fontSize = 20.sp, fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.width(4.dp))
 
-        Text(text = code, fontSize = 14.sp, color = Color.DarkGray)
+        Row(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .horizontalScroll(state = rememberScrollState(), enabled = !resizable),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(text = name, fontSize = 20.sp, fontWeight = FontWeight.Bold, maxLines = maxLines)
+
+            Text(text = code, fontSize = 14.sp, color = Color.DarkGray)
+        }
     }
 }
 

--- a/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/CardDetailsView.kt
+++ b/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/CardDetailsView.kt
@@ -153,10 +153,12 @@ private fun CardBasicInfo(cardDetails: CardDetails, modifier: Modifier = Modifie
             }
 
             // TODO: parse manaCost string to a visualized form
-            cardDetails.manaCost?.let { manaCost ->
-                Text(text = manaCost, textAlign = TextAlign.Center, fontSize = 16.sp)
-                LightHorizontalDivider()
-            }
+            cardDetails.manaCost
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { manaCost ->
+                    Text(text = manaCost, textAlign = TextAlign.Center, fontSize = 16.sp)
+                    LightHorizontalDivider()
+                }
 
             Text(
                 text = cardDetails.rarity.capitalize(),

--- a/feature/search/src/main/kotlin/com/donghanx/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/com/donghanx/search/SearchScreen.kt
@@ -20,12 +20,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.donghanx.design.R as DesignR
+import com.donghanx.model.SetInfo
 import com.donghanx.ui.SetInfoItem
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun SearchScreen(
     onCloseClick: () -> Unit,
+    onSetClick: (SetInfo) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SearchViewModel = hiltViewModel(),
 ) {
@@ -59,7 +61,12 @@ internal fun SearchScreen(
                 is SearchUiState.Success -> {
                     LazyColumn {
                         items(uiState.searchedSets) {
-                            SetInfoItem(code = it.code, name = it.name, iconUrl = it.iconSvgUri)
+                            SetInfoItem(
+                                code = it.code,
+                                name = it.name,
+                                iconUrl = it.iconSvgUri,
+                                onClick = { onSetClick(it) },
+                            )
                         }
                     }
                 }

--- a/feature/search/src/main/kotlin/com/donghanx/search/navigation/SearchNavigation.kt
+++ b/feature/search/src/main/kotlin/com/donghanx/search/navigation/SearchNavigation.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.donghanx.model.SetInfo
 import com.donghanx.search.SearchScreen
 
 const val SEARCH_ROUTE = "Search"
@@ -12,7 +13,7 @@ fun NavController.navigateToSearch() {
     navigate(route = SEARCH_ROUTE) { launchSingleTop = true }
 }
 
-fun NavGraphBuilder.searchScreen(onCloseClick: () -> Unit) {
+fun NavGraphBuilder.searchScreen(onCloseClick: () -> Unit, onSetClick: (SetInfo) -> Unit) {
     composable(
         route = SEARCH_ROUTE,
         enterTransition = {
@@ -22,6 +23,6 @@ fun NavGraphBuilder.searchScreen(onCloseClick: () -> Unit) {
             slideOutOfContainer(towards = AnimatedContentTransitionScope.SlideDirection.Down)
         },
     ) {
-        SearchScreen(onCloseClick = onCloseClick)
+        SearchScreen(onCloseClick = onCloseClick, onSetClick = onSetClick)
     }
 }

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
@@ -1,13 +1,75 @@
 package com.donghanx.setdetails
 
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import com.donghanx.design.R
+import com.donghanx.design.ui.text.ResizableText
+import com.donghanx.model.SetInfo
 
 @Composable
-fun SetDetailsScreen(viewModel: SetDetailsViewModel = hiltViewModel()) {
-    val setCode by viewModel.setCode.collectAsStateWithLifecycle()
-    setCode?.let { Text("set details for $it") }
+fun SetDetailsScreen(onBackClick: () -> Unit, viewModel: SetDetailsViewModel = hiltViewModel()) {
+    val setInfo by viewModel.setInfoFlow.collectAsStateWithLifecycle()
+    Column { SetDetailsTopBar(setInfo = setInfo, onBackClick = onBackClick) }
+}
+
+@Composable
+private fun SetDetailsTopBar(
+    setInfo: SetInfo?,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.fillMaxWidth().padding(bottom = 12.dp),
+    ) {
+        IconButton(onClick = onBackClick) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(id = R.string.back),
+            )
+        }
+
+        setInfo?.let {
+            SetDetailsTitle(name = it.name, iconUri = it.iconSvgUri, modifier = Modifier.weight(1F))
+        }
+
+        Spacer(modifier = Modifier.size(40.dp))
+    }
+}
+
+@Composable
+private fun SetDetailsTitle(name: String, iconUri: String, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        AsyncImage(model = iconUri, contentDescription = name, modifier = Modifier.size(24.dp))
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        ResizableText(text = name, fontSize = 20.sp, fontWeight = FontWeight.Bold)
+    }
 }

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
@@ -28,27 +28,38 @@ import coil.compose.AsyncImage
 import com.donghanx.common.extensions.capitalize
 import com.donghanx.design.R
 import com.donghanx.design.ui.text.ResizableText
+import com.donghanx.model.CardDetails
 import com.donghanx.model.SetInfo
 
 @Composable
 fun SetDetailsScreen(onBackClick: () -> Unit, viewModel: SetDetailsViewModel = hiltViewModel()) {
-    val setInfo by viewModel.setInfoFlow.collectAsStateWithLifecycle()
+    val setDetailsUiState by viewModel.setDetailsUiState.collectAsStateWithLifecycle()
+
     Column {
-        SetDetailsTopBar(setInfo = setInfo, onBackClick = onBackClick)
-        setInfo?.let { SetDetailsBasicInfo(setInfo = it) }
+        SetDetailsTopBar(setInfo = setDetailsUiState.setInfo, onBackClick = onBackClick)
+        SetDetailsBasicInfo(setInfo = setDetailsUiState.setInfo)
+
+        when (val uiState = setDetailsUiState) {
+            is SetDetailsUiState.Success -> {
+                CardsGalleryInSet(cardsInSet = uiState.cards)
+            }
+            is SetDetailsUiState.NoSetDetails -> {}
+        }
     }
 }
 
 @Composable
-private fun SetDetailsBasicInfo(setInfo: SetInfo, modifier: Modifier = Modifier) {
-    Row(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(space = 6.dp)) {
-        SuggestionChip(onClick = {}, label = { Text("${setInfo.cardCount} cards") })
+private fun SetDetailsBasicInfo(setInfo: SetInfo?, modifier: Modifier = Modifier) {
+    setInfo?.let {
+        Row(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(space = 6.dp)) {
+            SuggestionChip(onClick = {}, label = { Text("${it.cardCount} cards") })
 
-        SuggestionChip(onClick = {}, label = { Text("Type: ${setInfo.setType.capitalize()}") })
+            SuggestionChip(onClick = {}, label = { Text("Type: ${it.setType.capitalize()}") })
 
-        SuggestionChip(onClick = {}, label = { Text("Code: ${setInfo.code}") })
+            SuggestionChip(onClick = {}, label = { Text("Code: ${it.code}") })
 
-        SuggestionChip(onClick = {}, label = { Text("Released at ${setInfo.releasedAt}") })
+            SuggestionChip(onClick = {}, label = { Text("Released at ${it.releasedAt}") })
+        }
     }
 }
 
@@ -91,4 +102,9 @@ private fun SetDetailsTitle(name: String, iconUri: String, modifier: Modifier = 
 
         ResizableText(text = name, fontSize = 20.sp, fontWeight = FontWeight.Bold)
     }
+}
+
+@Composable
+private fun CardsGalleryInSet(cardsInSet: List<CardDetails>) {
+    Row { Text(text = "list size: ${cardsInSet.size}") }
 }

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -23,6 +25,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import com.donghanx.common.extensions.capitalize
 import com.donghanx.design.R
 import com.donghanx.design.ui.text.ResizableText
 import com.donghanx.model.SetInfo
@@ -30,7 +33,23 @@ import com.donghanx.model.SetInfo
 @Composable
 fun SetDetailsScreen(onBackClick: () -> Unit, viewModel: SetDetailsViewModel = hiltViewModel()) {
     val setInfo by viewModel.setInfoFlow.collectAsStateWithLifecycle()
-    Column { SetDetailsTopBar(setInfo = setInfo, onBackClick = onBackClick) }
+    Column {
+        SetDetailsTopBar(setInfo = setInfo, onBackClick = onBackClick)
+        setInfo?.let { SetDetailsBasicInfo(setInfo = it) }
+    }
+}
+
+@Composable
+private fun SetDetailsBasicInfo(setInfo: SetInfo, modifier: Modifier = Modifier) {
+    Row(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(space = 6.dp)) {
+        SuggestionChip(onClick = {}, label = { Text("${setInfo.cardCount} cards") })
+
+        SuggestionChip(onClick = {}, label = { Text("Type: ${setInfo.setType.capitalize()}") })
+
+        SuggestionChip(onClick = {}, label = { Text("Code: ${setInfo.code}") })
+
+        SuggestionChip(onClick = {}, label = { Text("Released at ${setInfo.releasedAt}") })
+    }
 }
 
 @Composable

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
@@ -1,15 +1,21 @@
 package com.donghanx.setdetails
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.SuggestionChip
@@ -18,32 +24,70 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
-import com.donghanx.common.extensions.capitalize
 import com.donghanx.design.R
+import com.donghanx.design.composable.provider.SharedTransitionProviderWrapper
+import com.donghanx.design.ui.grid.fullWidthItem
 import com.donghanx.design.ui.text.ResizableText
-import com.donghanx.model.CardDetails
+import com.donghanx.mock.MockUtils
+import com.donghanx.model.CardPreview
 import com.donghanx.model.SetInfo
+import com.donghanx.setdetails.navigation.SET_DETAILS_ROUTE
+import com.donghanx.ui.CardsGallery
 
 @Composable
-fun SetDetailsScreen(onBackClick: () -> Unit, viewModel: SetDetailsViewModel = hiltViewModel()) {
-    val setDetailsUiState by viewModel.setDetailsUiState.collectAsStateWithLifecycle()
+fun SetDetailsScreen(
+    onBackClick: () -> Unit,
+    onCardClick: (CardPreview) -> Unit,
+    viewModel: SetDetailsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.setDetailsUiState.collectAsStateWithLifecycle()
 
+    SetDetailsScreen(
+        setDetailsUiState = uiState,
+        onBackClick = onBackClick,
+        onCardClick = onCardClick,
+    )
+}
+
+@Composable
+private fun SetDetailsScreen(
+    setDetailsUiState: SetDetailsUiState,
+    onBackClick: () -> Unit,
+    onCardClick: (CardPreview) -> Unit,
+) {
     Column {
         SetDetailsTopBar(setInfo = setDetailsUiState.setInfo, onBackClick = onBackClick)
-        SetDetailsBasicInfo(setInfo = setDetailsUiState.setInfo)
 
-        when (val uiState = setDetailsUiState) {
-            is SetDetailsUiState.Success -> {
-                CardsGalleryInSet(cardsInSet = uiState.cards)
+        SetDetailsBasicInfo(
+            setInfo = setDetailsUiState.setInfo,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+        )
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 6.dp, horizontal = 4.dp))
+
+        Box(modifier = Modifier.fillMaxSize()) {
+            when (setDetailsUiState) {
+                is SetDetailsUiState.Success -> {
+                    CardsGalleryInSet(
+                        cardsInSet = setDetailsUiState.cards,
+                        releasedAt = setDetailsUiState.setInfo?.releasedAt,
+                        onCardClick = onCardClick,
+                    )
+                }
+                is SetDetailsUiState.NoSetDetails -> {}
+                is SetDetailsUiState.Loading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
             }
-            is SetDetailsUiState.NoSetDetails -> {}
         }
     }
 }
@@ -51,14 +95,15 @@ fun SetDetailsScreen(onBackClick: () -> Unit, viewModel: SetDetailsViewModel = h
 @Composable
 private fun SetDetailsBasicInfo(setInfo: SetInfo?, modifier: Modifier = Modifier) {
     setInfo?.let {
-        Row(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(space = 6.dp)) {
-            SuggestionChip(onClick = {}, label = { Text("${it.cardCount} cards") })
+        Row(
+            modifier = modifier.horizontalScroll(state = rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(space = 6.dp),
+        ) {
+            SuggestionChip(onClick = {}, label = { Text("type: ${it.setType}") })
 
-            SuggestionChip(onClick = {}, label = { Text("Type: ${it.setType.capitalize()}") })
+            SuggestionChip(onClick = {}, label = { Text("code: ${it.code}") })
 
-            SuggestionChip(onClick = {}, label = { Text("Code: ${it.code}") })
-
-            SuggestionChip(onClick = {}, label = { Text("Released at ${it.releasedAt}") })
+            SuggestionChip(onClick = {}, label = { Text("count: ${it.cardCount}") })
         }
     }
 }
@@ -72,7 +117,7 @@ private fun SetDetailsTopBar(
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.fillMaxWidth().padding(bottom = 12.dp),
+        modifier = modifier.fillMaxWidth().padding(bottom = 2.dp),
     ) {
         IconButton(onClick = onBackClick) {
             Icon(
@@ -105,6 +150,42 @@ private fun SetDetailsTitle(name: String, iconUri: String, modifier: Modifier = 
 }
 
 @Composable
-private fun CardsGalleryInSet(cardsInSet: List<CardDetails>) {
-    Row { Text(text = "list size: ${cardsInSet.size}") }
+private fun CardsGalleryInSet(
+    cardsInSet: List<CardPreview>,
+    releasedAt: String?,
+    onCardClick: (CardPreview) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CardsGallery(
+        parentRoute = SET_DETAILS_ROUTE,
+        cards = cardsInSet,
+        onCardClick = onCardClick,
+        header = {
+            fullWidthItem {
+                Text(
+                    text = "Released at $releasedAt",
+                    fontSize = 14.sp,
+                    color = Color.DarkGray,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+        },
+        modifier = modifier,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SetDetailsScreenPreview() {
+    SharedTransitionProviderWrapper {
+        SetDetailsScreen(
+            setDetailsUiState =
+                SetDetailsUiState.Success(
+                    cards = MockUtils.emptyCards,
+                    setInfo = MockUtils.soiExpansion,
+                ),
+            onBackClick = {},
+            onCardClick = {},
+        )
+    }
 }

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsViewModel.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsViewModel.kt
@@ -3,33 +3,130 @@ package com.donghanx.setdetails
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.donghanx.common.ErrorMessage
+import com.donghanx.common.emptyErrorMessage
+import com.donghanx.data.repository.setdetails.SetDetailsRepository
 import com.donghanx.data.repository.sets.SetsRepository
+import com.donghanx.model.CardDetails
 import com.donghanx.model.SetInfo
 import com.donghanx.setdetails.navigation.SET_ID_ARGS
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class SetDetailsViewModel
 @Inject
-constructor(savedStateHandle: SavedStateHandle, setsRepository: SetsRepository) : ViewModel() {
+constructor(
+    savedStateHandle: SavedStateHandle,
+    private val setsRepository: SetsRepository,
+    private val setDetailsRepository: SetDetailsRepository,
+) : ViewModel() {
 
     private val setIdFlow: StateFlow<String?> =
         savedStateHandle.getStateFlow(key = SET_ID_ARGS, initialValue = null)
 
-    val setInfoFlow: StateFlow<SetInfo?> =
-        setIdFlow
-            .filterNotNull()
-            .flatMapLatest { id -> setsRepository.getSetInfoById(id) }
+    private val setInfoFlow: Flow<SetInfo> =
+        setIdFlow.filterNotNull().flatMapLatest { id -> setsRepository.getSetInfoById(id) }
+
+    private val viewModelState = MutableStateFlow(SetDetailsViewModelState(refreshing = true))
+
+    val setDetailsUiState: StateFlow<SetDetailsUiState> =
+        viewModelState
+            .map(SetDetailsViewModelState::toUiState)
             .stateIn(
                 scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000L),
-                initialValue = null,
+                started = SharingStarted.WhileSubscribed(5_000L),
+                initialValue = viewModelState.value.toUiState(),
             )
 
+    init {
+        observeSetDetails()
+        refreshCardInSets()
+    }
+
+    private fun observeSetDetails() {
+        // TODO: create a UseCase to encapsulate the following code snippet
+        viewModelScope.launch {
+            setIdFlow
+                .filterNotNull()
+                .flatMapLatest { setId ->
+                    setsRepository.getSetInfoById(setId).flatMapLatest { setInfo ->
+                        setDetailsRepository.getCardsInCurrentSet(setInfo.code).map { cardsInSet ->
+                            SetInfoAndCards(setInfo, cardsInSet)
+                        }
+                    }
+                }
+                .onEach { (setInfo, cardsInSet) ->
+                    viewModelState.update { it.copy(setInfo = setInfo, cards = cardsInSet) }
+                }
+                .collect()
+        }
+    }
+
+    private fun refreshCardInSets() {
+        viewModelScope.launch {
+            setInfoFlow
+                .flatMapLatest { setInfo ->
+                    setDetailsRepository.refreshCardsInCurrentSet(searchUri = setInfo.searchUri)
+                }
+                .collect()
+        }
+    }
+}
+
+data class SetInfoAndCards(val setInfo: SetInfo, val cardsInSet: List<CardDetails>)
+
+sealed interface SetDetailsUiState {
+    val refreshing: Boolean
+    val errorMessage: ErrorMessage
+    val setInfo: SetInfo?
+
+    data class Success(
+        val cards: List<CardDetails>,
+        override val setInfo: SetInfo?,
+        override val refreshing: Boolean,
+        override val errorMessage: ErrorMessage = emptyErrorMessage(),
+    ) : SetDetailsUiState
+
+    data class NoSetDetails(
+        override val setInfo: SetInfo?,
+        override val refreshing: Boolean,
+        override val errorMessage: ErrorMessage = emptyErrorMessage(),
+    ) : SetDetailsUiState
+}
+
+private data class SetDetailsViewModelState(
+    val setInfo: SetInfo? = null,
+    val cards: List<CardDetails> = emptyList(),
+    val refreshing: Boolean,
+    val errorMessage: ErrorMessage = emptyErrorMessage(),
+) {
+    fun toUiState(): SetDetailsUiState =
+        when {
+            cards.isNotEmpty() ->
+                SetDetailsUiState.Success(
+                    setInfo = setInfo,
+                    cards = cards,
+                    refreshing = refreshing,
+                    errorMessage = errorMessage,
+                )
+            else ->
+                SetDetailsUiState.NoSetDetails(
+                    setInfo = setInfo,
+                    refreshing = refreshing,
+                    errorMessage = errorMessage,
+                )
+        }
 }

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsViewModel.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsViewModel.kt
@@ -3,24 +3,34 @@ package com.donghanx.setdetails
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.donghanx.setdetails.navigation.SET_CODE_ARGS
+import com.donghanx.data.repository.sets.SetsRepository
+import com.donghanx.model.SetInfo
+import com.donghanx.setdetails.navigation.SET_ID_ARGS
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 
 @HiltViewModel
-class SetDetailsViewModel @Inject constructor(private val savedStateHandle: SavedStateHandle) :
+class SetDetailsViewModel
+@Inject
+constructor(private val savedStateHandle: SavedStateHandle, setsRepository: SetsRepository) :
     ViewModel() {
 
-    private val setCodeFlow: StateFlow<String?> =
-        savedStateHandle.getStateFlow(key = SET_CODE_ARGS, initialValue = null)
+    private val setIdFlow: StateFlow<String?> =
+        savedStateHandle.getStateFlow(key = SET_ID_ARGS, initialValue = null)
 
-    val setCode =
-        setCodeFlow.stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000L),
-            initialValue = null,
-        )
+    val setInfoFlow: StateFlow<SetInfo?> =
+        setIdFlow
+            .filterNotNull()
+            .flatMapLatest { id -> setsRepository.getSetInfoById(id) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000L),
+                initialValue = null,
+            )
 }

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsViewModel.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsViewModel.kt
@@ -10,7 +10,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
@@ -18,8 +17,7 @@ import kotlinx.coroutines.flow.stateIn
 @HiltViewModel
 class SetDetailsViewModel
 @Inject
-constructor(private val savedStateHandle: SavedStateHandle, setsRepository: SetsRepository) :
-    ViewModel() {
+constructor(savedStateHandle: SavedStateHandle, setsRepository: SetsRepository) : ViewModel() {
 
     private val setIdFlow: StateFlow<String?> =
         savedStateHandle.getStateFlow(key = SET_ID_ARGS, initialValue = null)
@@ -33,4 +31,5 @@ constructor(private val savedStateHandle: SavedStateHandle, setsRepository: Sets
                 started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000L),
                 initialValue = null,
             )
+
 }

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/navigation/SetDetailsNavigation.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/navigation/SetDetailsNavigation.kt
@@ -6,15 +6,15 @@ import androidx.navigation.compose.composable
 import com.donghanx.setdetails.SetDetailsScreen
 
 private const val SET_DETAILS_ROUTE = "SetDetails"
-internal const val SET_CODE_ARGS = "SetCode"
+internal const val SET_ID_ARGS = "SetId"
 
-fun NavController.navigateToSetDetails(code: String, parentRoute: String) {
-    navigate("${setDetailsPrefixRoute(parentRoute)}/$code")
+fun NavController.navigateToSetDetails(setId: String, parentRoute: String) {
+    navigate("${setDetailsPrefixRoute(parentRoute)}/$setId")
 }
 
-fun NavGraphBuilder.setDetailsScreen(parentRoute: String) {
-    composable(route = "${setDetailsPrefixRoute(parentRoute)}/{$SET_CODE_ARGS}") {
-        SetDetailsScreen()
+fun NavGraphBuilder.setDetailsScreen(parentRoute: String, onBackClick: () -> Unit) {
+    composable(route = "${setDetailsPrefixRoute(parentRoute)}/{$SET_ID_ARGS}") {
+        SetDetailsScreen(onBackClick = onBackClick)
     }
 }
 

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/navigation/SetDetailsNavigation.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/navigation/SetDetailsNavigation.kt
@@ -1,20 +1,29 @@
 package com.donghanx.setdetails.navigation
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.donghanx.design.composable.provider.LocalNavAnimatedVisibilityScope
+import com.donghanx.model.CardPreview
 import com.donghanx.setdetails.SetDetailsScreen
 
-private const val SET_DETAILS_ROUTE = "SetDetails"
+const val SET_DETAILS_ROUTE = "SetDetails"
 internal const val SET_ID_ARGS = "SetId"
 
 fun NavController.navigateToSetDetails(setId: String, parentRoute: String) {
     navigate("${setDetailsPrefixRoute(parentRoute)}/$setId")
 }
 
-fun NavGraphBuilder.setDetailsScreen(parentRoute: String, onBackClick: () -> Unit) {
+fun NavGraphBuilder.setDetailsScreen(
+    parentRoute: String,
+    onBackClick: () -> Unit,
+    onCardClick: (CardPreview) -> Unit,
+) {
     composable(route = "${setDetailsPrefixRoute(parentRoute)}/{$SET_ID_ARGS}") {
-        SetDetailsScreen(onBackClick = onBackClick)
+        CompositionLocalProvider(LocalNavAnimatedVisibilityScope provides this) {
+            SetDetailsScreen(onBackClick = onBackClick, onCardClick = onCardClick)
+        }
     }
 }
 

--- a/feature/sets/src/main/kotlin/com/donghanx/sets/SetsScreen.kt
+++ b/feature/sets/src/main/kotlin/com/donghanx/sets/SetsScreen.kt
@@ -1,7 +1,6 @@
 package com.donghanx.sets
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -107,10 +106,8 @@ private fun SetsList(groupedSets: Map<Int, List<SetInfo>>, onSetClick: (SetInfo)
                         code = it.code,
                         name = it.name,
                         iconUrl = it.iconSvgUri,
-                        modifier =
-                            Modifier.fillMaxWidth().padding(horizontal = 6.dp).clickable {
-                                onSetClick(it)
-                            },
+                        onClick = { onSetClick(it) },
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 6.dp),
                     )
                 }
             }


### PR DESCRIPTION
**Summary**
This PR implements the complete UI functionality for the SetDetails screen, along with necessary updates to the data layer. 

Users can navigate to the SetDetails screen by tapping on any set name displayed in the SetsScreen. The details page presents key information about the selected set, with a CardsGallery that displays all the cards the set contains. The CardsGallery is also wired with the CardDetails screen, allowing users to easily view detailed information for each card.