### PR TITLE
Bump dependencies to the latest

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.coil.compose)
+    implementation(libs.coil.network)
     implementation(libs.coil.svg)
     implementation(libs.okhttp3)
     implementation(libs.okhttp3.tls)

--- a/app/src/main/kotlin/com/donghanx/nowinmtg/NowInMtgApplication.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/NowInMtgApplication.kt
@@ -1,33 +1,41 @@
 package com.donghanx.nowinmtg
 
 import android.app.Application
-import coil.ImageLoader
-import coil.ImageLoaderFactory
-import coil.decode.SvgDecoder
+import android.content.Context
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
+import coil3.svg.SvgDecoder
 import dagger.hilt.android.HiltAndroidApp
 import okhttp3.OkHttpClient
 import okhttp3.tls.HandshakeCertificates
 
 @HiltAndroidApp
-class NowInMtgApplication : Application(), ImageLoaderFactory {
+class NowInMtgApplication : Application(), SingletonImageLoader.Factory {
 
-    override fun newImageLoader(): ImageLoader {
+    override fun newImageLoader(context: Context): ImageLoader {
         return ImageLoader.Builder(applicationContext)
-            .okHttpClient {
-                val clientCertificates =
-                    HandshakeCertificates.Builder()
-                        .addPlatformTrustedCertificates()
-                        .addInsecureHost(INSECURE_MTG_HOST_NAME)
-                        .build()
+            .components {
+                add(
+                    OkHttpNetworkFetcherFactory(
+                        callFactory = {
+                            val clientCertificates =
+                                HandshakeCertificates.Builder()
+                                    .addPlatformTrustedCertificates()
+                                    .addInsecureHost(INSECURE_MTG_HOST_NAME)
+                                    .build()
 
-                OkHttpClient.Builder()
-                    .sslSocketFactory(
-                        clientCertificates.sslSocketFactory(),
-                        clientCertificates.trustManager,
+                            OkHttpClient.Builder()
+                                .sslSocketFactory(
+                                    clientCertificates.sslSocketFactory(),
+                                    clientCertificates.trustManager,
+                                )
+                                .build()
+                        }
                     )
-                    .build()
+                )
+                add(SvgDecoder.Factory())
             }
-            .components { add(SvgDecoder.Factory()) }
             .build()
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationComposeConventionPlugin.kt
@@ -7,7 +7,10 @@ import org.gradle.kotlin.dsl.getByType
 class AndroidApplicationComposeConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            pluginManager.apply("com.android.application")
+            with(pluginManager) {
+                apply("com.android.application")
+                apply("org.jetbrains.kotlin.plugin.compose")
+            }
             val extension = extensions.getByType<ApplicationExtension>()
 
             configureAndroidCompose(extension)

--- a/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -33,6 +33,7 @@ class AndroidFeatureConventionPlugin : Plugin<Project> {
 
                 add("implementation", libs.findLibrary("kotlinx.coroutines.android").get())
                 add("implementation", libs.findLibrary("coil.compose").get())
+                add("implementation", libs.findLibrary("coil.network").get())
                 add("implementation", libs.findLibrary("androidx.navigation.compose").get())
                 add("implementation", libs.findLibrary("androidx.hilt.navigation.compose").get())
             }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
@@ -7,7 +7,10 @@ import org.gradle.kotlin.dsl.getByType
 class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            pluginManager.apply("com.android.library")
+            with(pluginManager) {
+                apply("com.android.library")
+                apply("org.jetbrains.kotlin.plugin.compose")
+            }
             val extension = extensions.getByType<LibraryExtension>()
 
             configureAndroidCompose(extension)

--- a/build-logic/convention/src/main/kotlin/com/donghanx/convention/Project+Extensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/donghanx/convention/Project+Extensions.kt
@@ -11,6 +11,7 @@ import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val Project.libs: VersionCatalog
@@ -20,7 +21,7 @@ private typealias CommonExtensionType = CommonExtension<*, *, *, *, *, *>
 
 internal fun Project.configureKotlinAndroid(commonExtension: CommonExtensionType) {
     with(commonExtension) {
-        compileSdk = 34
+        compileSdk = 35
         defaultConfig { minSdk = 26 }
 
         compileOptions {
@@ -43,19 +44,20 @@ internal fun Project.configureKotlinJvm() {
 
 private fun Project.configureKotlin() {
     tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_18.toString()
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_18)
             // Treat all Kotlin warnings as errors (disabled by default)
             // Override by setting warningsAsErrors=true in your ~/.gradle/gradle.properties
             val warningsAsErrors: String? by project
-            allWarningsAsErrors = warningsAsErrors.toBoolean()
-            freeCompilerArgs =
-                freeCompilerArgs +
+            allWarningsAsErrors.set(warningsAsErrors.toBoolean())
+            freeCompilerArgs.set(
+                freeCompilerArgs.get() +
                     listOf(
                         "-opt-in=kotlin.RequiresOptIn",
                         "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
                         "-opt-in=kotlinx.coroutines.FlowPreview",
                     )
+            )
         }
     }
 }
@@ -63,11 +65,6 @@ private fun Project.configureKotlin() {
 internal fun Project.configureAndroidCompose(commonExtension: CommonExtensionType) {
     commonExtension.apply {
         buildFeatures { compose = true }
-
-        composeOptions {
-            kotlinCompilerExtensionVersion =
-                libs.findVersion("android.compose.compiler").get().toString()
-        }
 
         dependencies {
             val bom = libs.findLibrary("androidx.compose.bom").get()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     alias(libs.plugins.com.android.application) apply false
     alias(libs.plugins.org.jetbrains.kotlin.android) apply false
+    alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.com.android.library) apply false
     alias(libs.plugins.org.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.com.google.dagger.hilt.android) apply false

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
 
     implementation(libs.coil.compose)
+    implementation(libs.coil.network)
     implementation(libs.coil.svg)
 
     testImplementation(libs.junit)

--- a/core/ui/src/main/kotlin/com/donghanx/ui/CardsGallery.kt
+++ b/core/ui/src/main/kotlin/com/donghanx/ui/CardsGallery.kt
@@ -23,9 +23,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
-import coil.size.Precision
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.size.Precision
 import com.donghanx.design.R
 import com.donghanx.design.composable.extensions.isFirstItemNotVisible
 import com.donghanx.design.composable.extensions.rippleClickable

--- a/core/ui/src/main/kotlin/com/donghanx/ui/SetInfoItem.kt
+++ b/core/ui/src/main/kotlin/com/donghanx/ui/SetInfoItem.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImage
+import coil3.compose.AsyncImage
 
 @Composable
 fun SetInfoItem(

--- a/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/CardDetailsView.kt
+++ b/feature/carddetails/src/main/kotlin/com/donghanx/carddetails/CardDetailsView.kt
@@ -37,8 +37,9 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.placeholder
 import com.donghanx.common.extensions.capitalize
 import com.donghanx.design.composable.provider.LocalNavAnimatedVisibilityScope
 import com.donghanx.design.composable.provider.LocalSharedTransitionScope
@@ -97,7 +98,7 @@ private fun CardImage(
                 ImageRequest.Builder(LocalContext.current)
                     .data(imageUrl)
                     .placeholderMemoryCacheKey(cacheKey.toMemoryCacheKey())
-                    .apply { placeholderResId?.let(::placeholder) }
+                    .apply { placeholderResId?.let { placeholder(it) } }
                     .build(),
             contentDescription = contentDescription,
             modifier =

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
+import coil3.compose.AsyncImage
 import com.donghanx.design.R
 import com.donghanx.design.composable.provider.SharedTransitionProviderWrapper
 import com.donghanx.design.ui.grid.fullWidthItem

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,26 +1,24 @@
 [versions]
-kotlin = "1.9.25"
-agp = "8.6.0"
-androidx-compose-bom = "2024.09.01"
-activity-compose = "1.9.2"
-android-compose-compiler = "1.5.15"
+kotlin = "2.1.20"
+agp = "8.6.1"
+androidx-compose-bom = "2025.03.01"
+activity-compose = "1.10.1"
 androidx-junit = "1.1.5"
-core-ktx = "1.12.0"
-appcompat = "1.6.1"
+core-ktx = "1.15.0"
+appcompat = "1.7.0"
 espresso-core = "3.5.1"
 junit = "4.13.2"
-kotlinx-coroutines-android = "1.7.2"
-lifecycle = "2.6.2"
-material = "1.9.0"
-hilt = "2.47"
-kotlinx-serialization = "1.5.1"
-ktor = "2.3.4"
-okhttp = "4.11.0"
-room = "2.5.2"
-ksp = "1.9.10-1.0.13"
-coil = "2.7.0"
-navigation-compose = "2.8.0"
-hilt-navigation-compose = "1.0.0"
+kotlinx-coroutines-android = "1.10.1"
+lifecycle = "2.8.7"
+hilt = "2.51.1"
+kotlinx-serialization = "1.8.0"
+ktor = "3.1.2"
+okhttp = "4.12.0"
+room = "2.6.1"
+ksp = "2.1.20-1.0.32"
+coil = "3.1.0"
+navigation-compose = "2.8.9"
+hilt-navigation-compose = "1.2.0"
 spotless = "6.25.0"
 
 [libraries]
@@ -76,8 +74,9 @@ room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 
 # coil
-coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
-coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coil" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
+coil-network = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 
 # okhttp
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
@@ -87,6 +86,7 @@ okhttp3-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhtt
 com-android-application = { id = "com.android.application", version.ref = "agp" }
 com-android-library = { id = "com.android.library", version.ref = "agp" }
 org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 org-jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 com-google-dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 org-jetbrains-kotlin-plugin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
**Summary**

- Kotlin: `1.9.25` → `2.1.20`
- Compose BOM: `2024.09.00` → `2025.03.01`
- Lifecycle: `2.6.2` → `2.8.7`
- Ktor: `2.3.4` → `3.1.2`
- Coil: `2.7.0` → `3.1.0`
- Navigation-Compose: `2.8.0` → `2.8.9`
- Hilt-Navigation-Compose: `1.0.0 `→ `1.2.0`
- KSP: `1.9.10-1.0.13` → `2.1.20-1.0.32`

Additional changes include accommodating the artifact name space changes and new ImageLoader initialization from Coil3.