### PR TITLE
Preserve the random cards list order when inserting into DB table

### DIFF
--- a/core/data/src/main/kotlin/com/donghanx/data/repository/cards/OfflineFirstRandomCardsRepository.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/repository/cards/OfflineFirstRandomCardsRepository.kt
@@ -3,13 +3,12 @@ package com.donghanx.data.repository.cards
 import com.donghanx.common.NetworkResult
 import com.donghanx.common.asResultFlow
 import com.donghanx.common.foldResult
-import com.donghanx.data.sync.syncListWith
+import com.donghanx.data.sync.syncListIndexedWith
 import com.donghanx.database.RandomCardsDao
 import com.donghanx.database.model.RandomCardEntity
 import com.donghanx.database.model.asExternalModel
 import com.donghanx.database.model.asRandomCardEntity
 import com.donghanx.model.CardPreview
-import com.donghanx.model.network.NetworkCard
 import com.donghanx.network.CardsRemoteDataSource
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -37,8 +36,8 @@ constructor(
             .asResultFlow()
             .foldResult(
                 onSuccess = { randomCards ->
-                    randomCards.syncListWith(
-                        entityConverter = NetworkCard::asRandomCardEntity,
+                    randomCards.syncListIndexedWith(
+                        entityConverter = { index, entity -> entity.asRandomCardEntity(index) },
                         modelActions = randomCardsDao::deleteAllAndInsertRandomCards,
                     )
 

--- a/core/data/src/main/kotlin/com/donghanx/data/sync/EntitySyncer.kt
+++ b/core/data/src/main/kotlin/com/donghanx/data/sync/EntitySyncer.kt
@@ -8,6 +8,14 @@ suspend fun <T, R> List<T>.syncListWith(
         .also { localEntity -> modelActions(localEntity) }
 }
 
+suspend fun <T, R> List<T>.syncListIndexedWith(
+    entityConverter: (index: Int, networkEntity: T) -> R?,
+    modelActions: suspend (List<R>) -> Unit,
+) {
+    mapIndexedNotNull { index, networkEntity -> entityConverter(index, networkEntity) }
+        .also { localEntity -> modelActions(localEntity) }
+}
+
 suspend fun <T, R> T.syncWith(entityConverter: (T) -> R, modelActions: suspend (R) -> Unit) {
     entityConverter(this).also { localEntity -> modelActions(localEntity) }
 }

--- a/core/database/src/main/kotlin/com/donghanx/database/NimDatabase.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/NimDatabase.kt
@@ -20,7 +20,7 @@ import com.donghanx.database.model.SetEntity
             FavoriteCardEntity::class,
             RulingsEntity::class,
         ],
-    version = 5,
+    version = 6,
 )
 @TypeConverters(StringListTypeConverters::class, RulingsConverter::class)
 abstract class NimDatabase : RoomDatabase() {

--- a/core/database/src/main/kotlin/com/donghanx/database/RandomCardsDao.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/RandomCardsDao.kt
@@ -11,7 +11,8 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface RandomCardsDao {
 
-    @Query("SELECT * FROM random_cards") fun getRandomCards(): Flow<List<RandomCardEntity>>
+    @Query("SELECT * FROM random_cards ORDER BY orderIndex")
+    fun getRandomCards(): Flow<List<RandomCardEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertRandomCards(randomCards: List<RandomCardEntity>)

--- a/core/database/src/main/kotlin/com/donghanx/database/model/RandomCardEntity.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/model/RandomCardEntity.kt
@@ -11,10 +11,18 @@ data class RandomCardEntity(
     val name: String,
     val imageUrl: String?,
     val types: List<String>?,
+    val orderIndex: Int,
 )
 
-fun NetworkCard.asRandomCardEntity(): RandomCardEntity =
-    RandomCardEntity(multiverseId = multiverseId, name = name, imageUrl = imageUrl, types = types)
+fun NetworkCard.asRandomCardEntity(index: Int): RandomCardEntity =
+    RandomCardEntity(
+        multiverseId = multiverseId,
+        name = name,
+        imageUrl = imageUrl,
+        types = types,
+        // Preserve the order of items in the random cards list when inserting into database
+        orderIndex = index,
+    )
 
 fun RandomCardEntity.asExternalModel(): CardPreview =
     CardPreview(id = multiverseId.toString(), name = name, imageUrl = imageUrl)


### PR DESCRIPTION
**Summary**
Previously, the random cards list was being re-sorted by `multiverseId` when calling `getRandomCards()` because of the nature of table design and storage. This PR updates the logic to preserve the original insertion order, ensuring retrieval matches it exactly.

To achieve this, the index is now stored when converting the random cards network entity into its DB entity and is later used in the `GROUP BY` operation for `getRandomCards()` dao method.

Additionally, a new `EntityListSyncer` extension, `syncListIndexedWith`, has been introduced to provide the item index during entity conversion.