### PR TITLE
Bump spotless to 8.4.0 and ktfmt to 0.62

### DIFF
--- a/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgApp.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgApp.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
-import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScope
@@ -79,10 +78,6 @@ fun NowInMtgApp(
                 }
             },
             layoutType = adaptiveInfo.toNavigationSuiteType(appState.shouldShowLeftNavigationRail),
-            navigationSuiteColors =
-                NavigationSuiteDefaults.colors(
-                    navigationBarContainerColor = MaterialTheme.colorScheme.inverseOnSurface
-                ),
         ) {
             val topAppBarStates = rememberTopAppBarStatesByTopLevelDestination()
             val currentAppBarState =

--- a/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgAppState.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgAppState.kt
@@ -51,10 +51,9 @@ class NowInMtgAppState(
 
     val currentTopLevelDestination: TopLevelDestination?
         @Composable
-        get() =
-            topLevelDestinations.find { topLevelDestination ->
-                currentDestination?.hasRoute(route = topLevelDestination.route) == true
-            }
+        get() = topLevelDestinations.find { topLevelDestination ->
+            currentDestination?.hasRoute(route = topLevelDestination.route) == true
+        }
 
     val isTopLevelDestination: Boolean
         @Composable get() = currentTopLevelDestination != null

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 spotless {
     kotlin {
-        ktfmt("0.52").kotlinlangStyle()
+        ktfmt("0.62").kotlinlangStyle()
         target("**/*.kt")
         targetExclude("**/build/**/*.kt")
     }

--- a/core/database/src/main/kotlin/com/donghanx/database/model/RulingsEntity.kt
+++ b/core/database/src/main/kotlin/com/donghanx/database/model/RulingsEntity.kt
@@ -11,5 +11,6 @@ data class RulingsEntity(@PrimaryKey val cardId: String, val rulings: List<Netwo
 fun List<NetworkRuling>.asRulingsEntity(cardId: String): RulingsEntity =
     RulingsEntity(cardId = cardId, rulings = this)
 
-fun RulingsEntity.asExternalModel(): List<Ruling> =
-    rulings.map { Ruling(comment = it.comment, it.publishedAt, it.source) }
+fun RulingsEntity.asExternalModel(): List<Ruling> = rulings.map {
+    Ruling(comment = it.comment, it.publishedAt, it.source)
+}

--- a/core/domain/src/main/kotlin/com/donghanx/domain/ObserveCardDetailsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/donghanx/domain/ObserveCardDetailsUseCase.kt
@@ -24,12 +24,11 @@ constructor(private val cardDetailsRepository: CardDetailsRepository) {
                 )
                 .filterNotNull()
 
-        val rulingsFlow =
-            cardDetailsFlow.flatMapLatest { cardDetails ->
-                cardDetailsRepository.refreshCardRulingsById(cardDetails.id).mapLatest {
-                    cardDetailsRepository.oneshotGetCardRulingsById(cardDetails.id)
-                }
+        val rulingsFlow = cardDetailsFlow.flatMapLatest { cardDetails ->
+            cardDetailsRepository.refreshCardRulingsById(cardDetails.id).mapLatest {
+                cardDetailsRepository.oneshotGetCardRulingsById(cardDetails.id)
             }
+        }
 
         return combine(cardDetailsFlow, rulingsFlow) { cardDetails, rulings ->
             CardDetailsAndRulings(cardDetails, rulings)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ ksp = "2.1.20-1.0.32"
 coil = "3.1.0"
 navigation-compose = "2.8.9"
 hilt-navigation-compose = "1.2.0"
-spotless = "6.25.0"
+spotless = "8.4.0"
 kotlinx-immutable = "0.3.8"
 datastore = "1.2.0"
 


### PR DESCRIPTION
**Summary**
- `spotless`: `6.25.0` -> `8.4.0`
- `ktfmt`: `0.52` -> `0.62`
- Applied `./gradlew spotlessApply` to reformat the codebase according to the latest rules.