### PR TITLE
Sync BottomNavigationBar visibility with TopAppBar scroll state

### DIFF
--- a/app/src/main/kotlin/com/donghanx/nowinmtg/navigation/NimNavHost.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/navigation/NimNavHost.kt
@@ -34,6 +34,7 @@ import com.donghanx.settings.navigation.settingsDialog
 fun NimNavHost(
     navController: NavHostController,
     onScrollToTop: () -> Unit,
+    onTopBarVisibilityChanged: (isCollapsed: Boolean) -> Unit,
     onShowSnackbar: suspend (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -83,6 +84,7 @@ fun NimNavHost(
                                     parentRoute = SetDetailsRoute.toString(),
                                 )
                             },
+                            onTopBarVisibilityChanged = onTopBarVisibilityChanged,
                             onShowSnackbar = onShowSnackbar,
                         )
 

--- a/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgApp.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgApp.kt
@@ -17,17 +17,22 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldState
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScope
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+import androidx.compose.material3.adaptive.navigationsuite.rememberNavigationSuiteScaffoldState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -47,6 +52,10 @@ import com.donghanx.nowinmtg.navigation.rememberTopAppBarStatesByTopLevelDestina
 import com.donghanx.search.navigation.navigateToSearch
 import com.donghanx.settings.navigation.navigateToSettings
 import kotlin.reflect.KClass
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -59,6 +68,7 @@ fun NowInMtgApp(
         val appState = rememberNowInMtgAppState(windowSizeClass = windowSizeClass)
         val snackbarHostState = remember { SnackbarHostState() }
         val currentDestination = appState.currentDestination
+        val navigationSuiteState = rememberNavigationSuiteScaffoldState()
 
         NavigationSuiteScaffold(
             navigationSuiteItems = {
@@ -77,12 +87,18 @@ fun NowInMtgApp(
                     )
                 }
             },
+            state = navigationSuiteState,
             layoutType = adaptiveInfo.toNavigationSuiteType(appState.shouldShowLeftNavigationRail),
         ) {
             val topAppBarStates = rememberTopAppBarStatesByTopLevelDestination()
             val currentAppBarState =
                 topAppBarStates[appState.currentTopLevelDestination] ?: rememberTopAppBarState()
             val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(currentAppBarState)
+
+            if (!appState.shouldShowLeftNavigationRail) {
+                BottomNavigationBarScrollSyncEffect(scrollBehavior, navigationSuiteState)
+            }
+
             Scaffold(
                 // Only participate in nested scroll if the current screen is a top-level
                 // destination which has TopAppBar.
@@ -139,6 +155,28 @@ fun NowInMtgApp(
                 }
             }
         }
+    }
+}
+
+/**
+ * A LaunchedEffect that syncs [navigationSuiteState] visibility with the TopAppBar's
+ * [scrollBehavior] to provide an immersive scrolling experience in screens with a large set of
+ * contents.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BottomNavigationBarScrollSyncEffect(
+    scrollBehavior: TopAppBarScrollBehavior,
+    navigationSuiteState: NavigationSuiteScaffoldState,
+) {
+    LaunchedEffect(scrollBehavior) {
+        snapshotFlow { scrollBehavior.state.collapsedFraction }
+            .map { collapsedFraction -> collapsedFraction > 0.5F }
+            .distinctUntilChanged()
+            .onEach { isTopBarCollapsed ->
+                with(navigationSuiteState) { if (isTopBarCollapsed) hide() else show() }
+            }
+            .collect()
     }
 }
 

--- a/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgApp.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgApp.kt
@@ -145,6 +145,11 @@ fun NowInMtgApp(
                                 )
                             }
                         },
+                        onTopBarVisibilityChanged = { isTopBarCollapsed ->
+                            coroutineScope.launch {
+                                navigationSuiteState.hideOrShow(isTopBarCollapsed)
+                            }
+                        },
                         onShowSnackbar = { message ->
                             snackbarHostState.showSnackbar(
                                 message = message,
@@ -173,9 +178,7 @@ private fun BottomNavigationBarScrollSyncEffect(
         snapshotFlow { scrollBehavior.state.collapsedFraction }
             .map { collapsedFraction -> collapsedFraction > 0.5F }
             .distinctUntilChanged()
-            .onEach { isTopBarCollapsed ->
-                with(navigationSuiteState) { if (isTopBarCollapsed) hide() else show() }
-            }
+            .onEach { isTopBarCollapsed -> navigationSuiteState.hideOrShow(isTopBarCollapsed) }
             .collect()
     }
 }
@@ -214,3 +217,6 @@ private fun WindowAdaptiveInfo.toNavigationSuiteType(shouldShowNavigationRail: B
 
 private fun NavDestination?.withinTopLevelDestinationInHierarchy(route: KClass<*>): Boolean =
     this?.hierarchy?.any { it.hasRoute(route) } ?: false
+
+private suspend fun NavigationSuiteScaffoldState.hideOrShow(shouldCollapse: Boolean) =
+    if (shouldCollapse) hide() else show()

--- a/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgApp.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgApp.kt
@@ -17,7 +17,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.TopAppBarState
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
@@ -95,8 +95,8 @@ fun NowInMtgApp(
                 topAppBarStates[appState.currentTopLevelDestination] ?: rememberTopAppBarState()
             val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(currentAppBarState)
 
-            if (!appState.shouldShowLeftNavigationRail) {
-                BottomNavigationBarScrollSyncEffect(scrollBehavior, navigationSuiteState)
+            if (!appState.shouldShowLeftNavigationRail && appState.isTopLevelDestination) {
+                BottomNavigationBarScrollSyncEffect(scrollBehavior.state, navigationSuiteState)
             }
 
             Scaffold(
@@ -147,7 +147,9 @@ fun NowInMtgApp(
                         },
                         onTopBarVisibilityChanged = { isTopBarCollapsed ->
                             coroutineScope.launch {
-                                navigationSuiteState.hideOrShow(isTopBarCollapsed)
+                                if (!appState.shouldShowLeftNavigationRail) {
+                                    navigationSuiteState.hideOrShow(isTopBarCollapsed)
+                                }
                             }
                         },
                         onShowSnackbar = { message ->
@@ -171,11 +173,11 @@ fun NowInMtgApp(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BottomNavigationBarScrollSyncEffect(
-    scrollBehavior: TopAppBarScrollBehavior,
+    appBarState: TopAppBarState,
     navigationSuiteState: NavigationSuiteScaffoldState,
 ) {
-    LaunchedEffect(scrollBehavior) {
-        snapshotFlow { scrollBehavior.state.collapsedFraction }
+    LaunchedEffect(appBarState) {
+        snapshotFlow { appBarState.collapsedFraction }
             .map { collapsedFraction -> collapsedFraction > 0.5F }
             .distinctUntilChanged()
             .onEach { isTopBarCollapsed -> navigationSuiteState.hideOrShow(isTopBarCollapsed) }

--- a/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgApp.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/ui/NowInMtgApp.kt
@@ -166,9 +166,8 @@ fun NowInMtgApp(
 }
 
 /**
- * A LaunchedEffect that syncs [navigationSuiteState] visibility with the TopAppBar's
- * [scrollBehavior] to provide an immersive scrolling experience in screens with a large set of
- * contents.
+ * A LaunchedEffect that syncs [navigationSuiteState] visibility with the TopAppBar's [appBarState]
+ * to provide an immersive scrolling experience in screens with a large set of contents.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/core/design/src/main/kotlin/com/donghanx/design/ui/appbar/CollapsingAppBarNestedScrollConnection.kt
+++ b/core/design/src/main/kotlin/com/donghanx/design/ui/appbar/CollapsingAppBarNestedScrollConnection.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 
 @Stable
@@ -17,6 +18,9 @@ class CollapsingNestedScrollConnection(val maxHeight: Int) : NestedScrollConnect
     private var _targetOffset by mutableFloatStateOf(0F)
     val targetOffset: Int
         get() = _targetOffset.roundToInt()
+
+    val absoluteTargetOffset: Float
+        get() = targetOffset.absoluteValue.toFloat()
 
     override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
         val delta = available.y

--- a/core/design/src/main/kotlin/com/donghanx/design/ui/appbar/CollapsingAppBarNestedScrollConnection.kt
+++ b/core/design/src/main/kotlin/com/donghanx/design/ui/appbar/CollapsingAppBarNestedScrollConnection.kt
@@ -20,7 +20,7 @@ class CollapsingNestedScrollConnection(val maxHeight: Int) : NestedScrollConnect
         get() = _targetOffset.roundToInt()
 
     val absoluteTargetOffset: Float
-        get() = targetOffset.absoluteValue.toFloat()
+        get() = _targetOffset.absoluteValue
 
     override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
         val delta = available.y

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
@@ -55,6 +55,7 @@ import com.donghanx.design.R as DesignR
 import com.donghanx.design.composable.extensions.hasEnoughItemsToScroll
 import com.donghanx.design.composable.extensions.toDp
 import com.donghanx.design.composable.provider.SharedTransitionProviderWrapper
+import com.donghanx.design.ui.appbar.CollapsingNestedScrollConnection
 import com.donghanx.design.ui.appbar.rememberCollapsingNestedScrollConnection
 import com.donghanx.design.ui.grid.fullWidthItem
 import com.donghanx.design.ui.placeholder.EmptyScreenWithIcon
@@ -71,6 +72,7 @@ import kotlinx.collections.immutable.toImmutableList
 internal fun SetDetailsScreen(
     onBackClick: () -> Unit,
     onCardClick: (CardPreview) -> Unit,
+    onTopBarVisibilityChanged: (isCollapsed: Boolean) -> Unit,
     onShowSnackbar: suspend (String) -> Unit,
     viewModel: SetDetailsViewModel = hiltViewModel(),
 ) {
@@ -80,6 +82,7 @@ internal fun SetDetailsScreen(
         setDetailsUiState = uiState,
         onBackClick = onBackClick,
         onCardClick = onCardClick,
+        onTopBarVisibilityChanged = onTopBarVisibilityChanged,
         onShowSnackbar = onShowSnackbar,
     )
 }
@@ -89,6 +92,7 @@ private fun SetDetailsScreen(
     setDetailsUiState: SetDetailsUiState,
     onBackClick: () -> Unit,
     onCardClick: (CardPreview) -> Unit,
+    onTopBarVisibilityChanged: (isCollapsed: Boolean) -> Unit,
     onShowSnackbar: suspend (String) -> Unit,
 ) {
     val lazyGridState = rememberLazyGridState()
@@ -110,6 +114,12 @@ private fun SetDetailsScreen(
                 (appBarMaxHeightPx + offset).toDp(density)
             }
         }
+
+    TopNavigationBarScrollSyncEffect(
+        appBarMaxHeightPx = appBarMaxHeightPx,
+        nestedScrollConnection = nestedScrollConnection,
+        onTopBarVisibilityChanged = onTopBarVisibilityChanged,
+    )
 
     // TODO: Fix scroll flickering for short content lists where the scrollable range is
     //  smaller than the SetDetailsHeader height.
@@ -284,6 +294,20 @@ private fun CardsGalleryInSet(
     )
 }
 
+@Composable
+private fun TopNavigationBarScrollSyncEffect(
+    appBarMaxHeightPx: Int,
+    nestedScrollConnection: CollapsingNestedScrollConnection,
+    onTopBarVisibilityChanged: (isCollapsed: Boolean) -> Unit,
+) {
+    val collapsedFraction by remember {
+        derivedStateOf { nestedScrollConnection.absoluteTargetOffset / appBarMaxHeightPx }
+    }
+    val isTopbarCollapsed by remember { derivedStateOf { collapsedFraction > 0.5F } }
+
+    LaunchedEffect(isTopbarCollapsed) { onTopBarVisibilityChanged(isTopbarCollapsed) }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun SetDetailsScreenPreview() {
@@ -297,6 +321,7 @@ private fun SetDetailsScreenPreview() {
                 ),
             onBackClick = {},
             onCardClick = {},
+            onTopBarVisibilityChanged = {},
             onShowSnackbar = {},
         )
     }

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
@@ -115,7 +115,7 @@ private fun SetDetailsScreen(
             }
         }
 
-    TopNavigationBarScrollSyncEffect(
+    TopBarScrollSyncEffect(
         appBarMaxHeightPx = appBarMaxHeightPx,
         nestedScrollConnection = nestedScrollConnection,
         onTopBarVisibilityChanged = onTopBarVisibilityChanged,
@@ -295,7 +295,7 @@ private fun CardsGalleryInSet(
 }
 
 @Composable
-private fun TopNavigationBarScrollSyncEffect(
+private fun TopBarScrollSyncEffect(
     appBarMaxHeightPx: Int,
     nestedScrollConnection: CollapsingNestedScrollConnection,
     onTopBarVisibilityChanged: (isCollapsed: Boolean) -> Unit,

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
@@ -300,9 +300,10 @@ private fun TopNavigationBarScrollSyncEffect(
     nestedScrollConnection: CollapsingNestedScrollConnection,
     onTopBarVisibilityChanged: (isCollapsed: Boolean) -> Unit,
 ) {
-    val collapsedFraction by remember(appBarMaxHeightPx) {
-        derivedStateOf { nestedScrollConnection.absoluteTargetOffset / appBarMaxHeightPx }
-    }
+    val collapsedFraction by
+        remember(appBarMaxHeightPx) {
+            derivedStateOf { nestedScrollConnection.absoluteTargetOffset / appBarMaxHeightPx }
+        }
     val isTopbarCollapsed by remember { derivedStateOf { collapsedFraction > 0.5F } }
 
     LaunchedEffect(isTopbarCollapsed) { onTopBarVisibilityChanged(isTopbarCollapsed) }

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/SetDetailsScreen.kt
@@ -300,7 +300,7 @@ private fun TopNavigationBarScrollSyncEffect(
     nestedScrollConnection: CollapsingNestedScrollConnection,
     onTopBarVisibilityChanged: (isCollapsed: Boolean) -> Unit,
 ) {
-    val collapsedFraction by remember {
+    val collapsedFraction by remember(appBarMaxHeightPx) {
         derivedStateOf { nestedScrollConnection.absoluteTargetOffset / appBarMaxHeightPx }
     }
     val isTopbarCollapsed by remember { derivedStateOf { collapsedFraction > 0.5F } }

--- a/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/navigation/SetDetailsNavigation.kt
+++ b/feature/setdetails/src/main/kotlin/com/donghanx/setdetails/navigation/SetDetailsNavigation.kt
@@ -18,6 +18,7 @@ fun NavController.navigateToSetDetails(setId: String, parentRoute: String) {
 fun NavGraphBuilder.setDetailsScreen(
     onBackClick: () -> Unit,
     onCardClick: (CardPreview) -> Unit,
+    onTopBarVisibilityChanged: (isCollapsed: Boolean) -> Unit,
     onShowSnackbar: suspend (String) -> Unit,
 ) {
     composable<SetDetailsRoute> {
@@ -25,6 +26,7 @@ fun NavGraphBuilder.setDetailsScreen(
             SetDetailsScreen(
                 onBackClick = onBackClick,
                 onCardClick = onCardClick,
+                onTopBarVisibilityChanged = onTopBarVisibilityChanged,
                 onShowSnackbar = onShowSnackbar,
             )
         }


### PR DESCRIPTION
**Summary**
Previously, when the inner content of Scaffold is scrolling up, only the `TopAppBar` will collapse while the bottom navigation bar remained visible. This resulted in a less immersive reading experience.

To address the issue, this PR introduces collapse/expand behavior for the `BottomNavigationBar`, aligning it with the `TopAppBar`'s scroll behavior using `NavigationSuiteScaffoldState`. This behavior is applied to screens with possibly large content sets, including `Random Cards`, `Sets`, `Favorites`, and `Set Details`.

Note that on devices with `WindowWidthSizeClass.Medium` and `WindowWidthSizeClass.Expanded`, a `NavigationRail` is used instead. Since it is positioned on the left side, it should remain static and is not affected by this change.

https://github.com/user-attachments/assets/2685defa-5e95-4391-94ba-adb0bfbb3448