### PR TITLE
Add User-Agent header to Scryfall API requests

### DIFF
--- a/app/src/main/kotlin/com/donghanx/nowinmtg/NowInMtgApplication.kt
+++ b/app/src/main/kotlin/com/donghanx/nowinmtg/NowInMtgApplication.kt
@@ -6,6 +6,7 @@ import coil3.ImageLoader
 import coil3.SingletonImageLoader
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.svg.SvgDecoder
+import com.donghanx.common.USER_AGENT
 import dagger.hilt.android.HiltAndroidApp
 import okhttp3.OkHttpClient
 import okhttp3.tls.HandshakeCertificates
@@ -30,6 +31,15 @@ class NowInMtgApplication : Application(), SingletonImageLoader.Factory {
                                     clientCertificates.sslSocketFactory(),
                                     clientCertificates.trustManager,
                                 )
+                                .addInterceptor { chain ->
+                                    chain.proceed(
+                                        chain
+                                            .request()
+                                            .newBuilder()
+                                            .header(name = "User-Agent", value = USER_AGENT)
+                                            .build()
+                                    )
+                                }
                                 .build()
                         }
                     )

--- a/core/common/src/main/kotlin/com/donghanx/common/NetworkConstants.kt
+++ b/core/common/src/main/kotlin/com/donghanx/common/NetworkConstants.kt
@@ -1,0 +1,13 @@
+package com.donghanx.common
+
+/**
+ * Identifies this app to the APIs and CDNs it talks to.
+ *
+ * Scryfall requires every request to `api.scryfall.com` to carry a User-Agent header that should
+ * reflect the app's name and version, instead of a default value chosen by the HTTP library.
+ *
+ * See also the
+ * [Scryfall blog](https://scryfall.com/blog/user-agent-and-accept-header-now-required-on-the-api-225)
+ * for more information.
+ */
+const val USER_AGENT = "NowInMtg/1.0 (Android)"

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -24,6 +24,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":core:common"))
     implementation(project(":core:model"))
     implementation(libs.kotlinx.serialization)
     implementation(libs.kotlinx.coroutines.android)

--- a/core/network/src/main/kotlin/com/donghanx/network/client/BaseHttpClient.kt
+++ b/core/network/src/main/kotlin/com/donghanx/network/client/BaseHttpClient.kt
@@ -1,8 +1,10 @@
 package com.donghanx.network.client
 
+import com.donghanx.common.USER_AGENT
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.UserAgent
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.header
 import io.ktor.http.ContentType
@@ -27,6 +29,8 @@ internal fun baseHttpClient(baseUrl: String): HttpClient {
                 }
             )
         }
+
+        install(UserAgent) { agent = USER_AGENT }
 
         install(DefaultRequest) {
             header(HttpHeaders.ContentType, ContentType.Application.Json)


### PR DESCRIPTION
**Summary**
This PR adds a `User-Agent` header identifying this app by name and version to all outgoing requests to `api.scryfall.com`. The header applies in the following places:

- The Ktor `HttpClient` used for Scryfall API calls
- The `OkHttp` interceptor backing Coil's image loader, so card image requests to Scryfall's CDN carry the header too

See the [Scryfall blog](https://scryfall.com/blog/user-agent-and-accept-header-now-required-on-the-api-225) for more information.